### PR TITLE
removing the line that was causing the issue

### DIFF
--- a/cldk/analysis/java/codeanalyzer/codeanalyzer.py
+++ b/cldk/analysis/java/codeanalyzer/codeanalyzer.py
@@ -828,7 +828,7 @@ class JCodeanalyzer:
                 )
                 if call_edge not in cg:
                     cg.append(call_edge)
-                cg = self.__raw_call_graph_using_symbol_table(qualified_class_name=target_class, method_signature=target_method_details.signature, cg=cg)
+                # cg = self.__raw_call_graph_using_symbol_table(qualified_class_name=target_class, method_signature=target_method_details.signature, cg=cg)
         return cg
 
     def get_class_call_graph(self, qualified_class_name: str, method_name: str | None = None) -> List[Tuple[JMethodDetail, JMethodDetail]]:


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
We hit maximum recursion depth because of a spurious recursive call in `__raw_call_graph_using_symbol_table()`

## How Has This Been Tested?
The following test case should now run—
```python
class_name = 'org.apache.commons.codec.language.bm.Rule'
signature = 'parseRules(Scanner, String)'
analysis = CLDK(language="java").analysis(
 project_path='commons-codec',
 analysis_backend="codeanalyzer",
 analysis_backend_path=None,
 analysis_level=AnalysisLevel.call_graph,
 analysis_json_path='./'
)
callee_info = analysis.get_class_call_graph(class_name, signature, True)
self.assertIsNotNone(callee_info)
```

## Breaking Changes
No

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [X] I have read the [Codellm-Devkit Documentation](https://codellm-devkit.info)
- [X] My code follows the repository's style guidelines
- [X] ~New and~ existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

N/A