### PR TITLE
Update get_all_docstrings to return dict

### DIFF
--- a/cldk/analysis/java/codeanalyzer/codeanalyzer.py
+++ b/cldk/analysis/java/codeanalyzer/codeanalyzer.py
@@ -1079,8 +1079,10 @@ class JCodeanalyzer:
         Returns:
             Dict[str, List[str]]: Dictionary of file paths and their corresponding docstrings.
         """
-        docstrings = []
+        docstrings = {}
         for file_path, list_of_comments in self.get_all_comments().items():
-            docstrings += [(file_path, docstring) for docstring in list_of_comments if docstring.is_javadoc]
+            javadoc_comments = [docstring for docstring in list_of_comments if docstring.is_javadoc]
+            if javadoc_comments:
+                docstrings[file_path] = javadoc_comments
 
         return docstrings


### PR DESCRIPTION
small change to return dictionary instead of string as expect in the documentation.

## Motivation and Context
This was the intended output of the function

## How Has This Been Tested?
Local testing was completed using java repos.

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [Codellm-Devkit Documentation](https://codellm-devkit.info)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

