### PR TITLE
fix(java): retire source-mode witnesses and refuse a None cache dir (#328)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -312,6 +312,18 @@ Python legs 1 and 1.5 of the CLDK 2.0 agent-facing query facade (see
   schema probe at attach time; see the breaking-change note above.
 
 ### Fixed
+- **Java: a missing JDK cache root is refused, not crashed on.** `JCodeanalyzer._get_codeanalyzer_exec`
+  now raises `CodeanalyzerExecutionException` ("no cache directory and no project directory")
+  when neither is available, instead of letting `ensure_jdk` fail with `TypeError: ... not
+  'NoneType'`. Only single-file source mode reaches this path; that mode is won't-fix (#256) and
+  its ten witness tests are skip-gated under #255, so the release test gate (live since #306) is
+  green again (#328).
+- **Java: the cached Temurin JDK is actually reused.** `ensure_jdk` looked for `<cache>/jdk/<release>/bin/java`,
+  but the archive extracts nested (`<release>/bin`, or `<release>/Contents/Home/bin` on macOS), so
+  the cache never hit; without a `$JAVA_HOME` carrying `jmods` every process re-downloaded the JDK
+  and then failed extracting over the read-only `lib/server/*.jsa` files already there. It now
+  finds the extracted JDK the same way the download does. Mocked-analyzer Java tests no longer
+  resolve a JDK at all, and `JAVA_HOME` no longer leaks between tests.
 - **Neo4j statements no longer leak across applications in a shared database.** The per-parent
   child fetches (`get_class()` and everything reconstructing one declaration) matched by a bare
   `{signature: $sig}` / `{file_key: $fk}` while their bulk twins were application-scoped, so in a

--- a/cldk/analysis/java/codeanalyzer/_jdk.py
+++ b/cldk/analysis/java/codeanalyzer/_jdk.py
@@ -164,10 +164,15 @@ def ensure_jdk(java_cache_dir: Path) -> Path:
       3. otherwise download + extract the pinned Temurin JDK into the cache.
     """
     home = Path(java_cache_dir) / "jdk" / JDK_RELEASE
-    java = home / "bin" / ("java.exe" if os.name == "nt" else "java")
-    if java.exists() and (home / "jmods").is_dir():
-        logger.debug(f"Reusing cached JDK at {home}")
-        return home
+    # The archive extracts nested (<home>/<release>/bin, or .../Contents/Home/bin on mac), so look
+    # for the JDK the same way download_and_extract did rather than at <home>/bin.
+    try:
+        cached = JdkLoader._java_home(home)
+    except FileNotFoundError:
+        pass
+    else:
+        logger.debug(f"Reusing cached JDK at {cached}")
+        return cached
 
     sys_home = os.environ.get("JAVA_HOME")
     if sys_home and (Path(sys_home) / "jmods").is_dir():

--- a/cldk/analysis/java/codeanalyzer/codeanalyzer.py
+++ b/cldk/analysis/java/codeanalyzer/codeanalyzer.py
@@ -111,6 +111,11 @@ class JCodeanalyzer(JavaAnalysisBackend):
         # analysis_json_path IS the java cache subdir (cache_subdir(cache_dir, project, "java"));
         # fall back to the same helper in source/pipe mode where it is None.
         java_cache = Path(self.analysis_json_path) if self.analysis_json_path else cache_subdir(None, self.project_dir, "java")
+        if java_cache is None:
+            raise CodeanalyzerExecutionException(
+                "Cannot resolve a JDK cache directory: no cache directory and no project directory "
+                "-- single-file source mode cannot host a JDK (unsupported, see #256)."
+            )
         java_home = ensure_jdk(java_cache)
         # ScopeUtils reads the JAVA_HOME env var (not java.home); child procs inherit os.environ.
         os.environ["JAVA_HOME"] = str(java_home)

--- a/tests/analysis/java/conftest.py
+++ b/tests/analysis/java/conftest.py
@@ -1,0 +1,29 @@
+import os
+from unittest import mock
+
+import pytest
+
+import cldk.analysis.java.codeanalyzer.codeanalyzer as _codeanalyzer
+
+
+@pytest.fixture(autouse=True)
+def _no_jdk_for_mocked_analyzer(monkeypatch, tmp_path):
+    """Tests that patch ``subprocess.run`` never launch a JVM, so do not resolve one for them.
+
+    ``_get_codeanalyzer_exec`` calls ``ensure_jdk`` before every analyzer run; without a
+    ``$JAVA_HOME`` that carries ``jmods`` that is a Temurin download into a fresh cache dir
+    (#328). Tests that run the real jar (``subprocess.run`` unpatched) still get the real lookup.
+    ``JAVA_HOME`` is restored afterwards because ``_get_codeanalyzer_exec`` exports it.
+    """
+    real_ensure_jdk = _codeanalyzer.ensure_jdk
+
+    def ensure_jdk(java_cache_dir):
+        if isinstance(_codeanalyzer.subprocess.run, mock.Mock):
+            return tmp_path / "jdk"
+        return real_ensure_jdk(java_cache_dir)
+
+    monkeypatch.setattr(_codeanalyzer, "ensure_jdk", ensure_jdk)
+    if "JAVA_HOME" in os.environ:
+        monkeypatch.setenv("JAVA_HOME", os.environ["JAVA_HOME"])
+    else:
+        monkeypatch.delenv("JAVA_HOME", raising=False)

--- a/tests/analysis/java/test_inheritance_call_graph.py
+++ b/tests/analysis/java/test_inheritance_call_graph.py
@@ -10,6 +10,7 @@ from cldk import CLDK
 from cldk.analysis import AnalysisLevel
 
 
+@pytest.mark.skip(reason="Java single-file source analysis is won't-fix (#256); witness retired under #255")
 class TestInheritanceCallGraphIntegration:
     """Test suite for inheritance support in call graph generation."""
 

--- a/tests/analysis/java/test_java_analysis.py
+++ b/tests/analysis/java/test_java_analysis.py
@@ -69,6 +69,7 @@ def test_get_symbol_table_is_not_null(test_fixture, analysis_json):
         )
         assert analysis.get_symbol_table() is not None
 
+@pytest.mark.skip(reason="Java single-file source analysis is won't-fix (#256); witness retired under #255")
 def test_get_symbol_table_source_code(java_code):
     """Should return a symbol table for source analysis with expected class/method count"""
 
@@ -681,6 +682,7 @@ def test_get_fields(test_fixture, analysis_json):
             assert field.variable_initializers is None
 
 
+@pytest.mark.skip(reason="Java single-file source analysis is won't-fix (#256); witness retired under #255")
 def test_get_fields_variable_initializers(java_code):
     """Should return per-variable initializer text for fields"""
 

--- a/tests/analysis/java/test_jcodeanalyzer.py
+++ b/tests/analysis/java/test_jcodeanalyzer.py
@@ -23,11 +23,14 @@ import json
 from typing import Dict, List, Tuple
 from unittest.mock import patch, MagicMock
 import networkx as nx
+import pytest
 
 from cldk.analysis import AnalysisLevel
 from cldk.analysis.java.codeanalyzer import JCodeanalyzer
 from cldk.models.java.models import JApplication, JCRUDOperation, JType, JCallable, JCompilationUnit, JImport, JMethodDetail
 from cldk.models.java import JGraphEdges
+from cldk.utils.exceptions.exceptions import CodeanalyzerExecutionException
+from cldk.analysis.java.codeanalyzer import _jdk
 
 
 def _build_analysis_json_payload(version: str, imports: list[dict[str, object] | str], include_call_graph: bool = False) -> dict:
@@ -223,6 +226,31 @@ def test_generate_call_graph(test_fixture, analysis_json):
         assert isinstance(int(edge[2]["weight"]), int)
         assert isinstance(edge[2]["calling_lines"], list)
         # assert all(isinstance(line, str) for line in edge[2]["calling_lines"])
+
+
+def test_source_mode_without_project_dir_is_refused_before_jdk_lookup():
+    """Should raise CodeanalyzerExecutionException, not TypeError, when neither cache nor project dir exists (#328)"""
+    with pytest.raises(CodeanalyzerExecutionException, match="no cache directory and no project directory"):
+        JCodeanalyzer(
+            project_dir=None,
+            source_code="class A {}",
+            analysis_json_path=None,
+            analysis_level=AnalysisLevel.symbol_table,
+            eager_analysis=False,
+            target_files=None,
+        )
+
+
+def test_ensure_jdk_reuses_the_nested_extracted_jdk_without_downloading(tmp_path, monkeypatch):
+    """Should find the cached JDK in its extracted (nested) layout instead of re-downloading over it (#328)"""
+    home = tmp_path / "jdk" / _jdk.JDK_RELEASE / _jdk.JDK_RELEASE / "Contents" / "Home"
+    (home / "bin").mkdir(parents=True)
+    (home / "bin" / "java").touch()
+    (home / "jmods").mkdir()
+    monkeypatch.delenv("JAVA_HOME", raising=False)
+    monkeypatch.setattr(_jdk.JdkLoader, "download_and_extract", lambda *a, **k: pytest.fail("attempted a JDK download"))
+
+    assert _jdk.ensure_jdk(tmp_path) == home.resolve()
 
 
 def test_codeanalyzer_single_file(test_fixture, analysis_json):


### PR DESCRIPTION
Closes #328. Unblocks the `2.0.0rc2` tag.

## Why

The `v1.5.0` release run (`30300820857`, commit `dd4870d`) was **red** — `11 failed, 253 passed, 33 skipped` — and published anyway because the "Delete tag on failure" step tested `steps.test.conclusion`, which `continue-on-error` forces to `success`. #306 made the gate real on `release/2.0`; the next tag pushed here runs `make test` and deletes itself unless the suite is 0 failed. Ten of those eleven failures are still present on `release/2.0` (the eleventh, the native-binary resolution test, was already removed).

All ten construct the Java backend in **single-file source mode** (`CLDK(language="java").analysis(source_code=...)`): no cache dir and no project dir, so `cache_subdir(None, None, "java")` returns `None` and `ensure_jdk` dies on `Path(None)`. #256 records that mode as won't-fix (removal in the 2.0.0 breaking window); #255 says its witnesses get "removed or skip-gated".

## What

- **Skip-gate the ten witnesses** (`tests/analysis/java/test_inheritance_call_graph.py`, class-level; `tests/analysis/java/test_java_analysis.py`, `test_get_symbol_table_source_code` and `test_get_fields_variable_initializers`) with `reason="Java single-file source analysis is won't-fix (#256); witness retired under #255"`. Skipped rather than deleted so the history stays visible in every run's skip report.
- **`None` can no longer reach `Path()`.** `JCodeanalyzer._get_codeanalyzer_exec` raises `CodeanalyzerExecutionException` ("no cache directory and no project directory -- single-file source mode cannot host a JDK") before `ensure_jdk`. Unit-tested with no Java, jar or network (`test_source_mode_without_project_dir_is_refused_before_jdk_lookup`).
- **Second-order effect (#328's warning), investigated and fixed.** `ensure_jdk` never hit its own cache: it checked `<cache>/jdk/<release>/bin/java`, but the archive extracts nested (`<release>/bin`, or `<release>/Contents/Home/bin` on macOS). Without a `$JAVA_HOME` carrying `jmods`, every process re-downloaded Temurin — and, if a previous extraction was already there, failed with `PermissionError` on the read-only `lib/server/*.jsa` files. Locally this was masked only because `_get_codeanalyzer_exec` exports `JAVA_HOME` and the leaked value from the first download rescued every later test in the same process. The cache check now uses `JdkLoader._java_home`, the same lookup the download uses. Unit-tested against a fake nested layout with the download stubbed to fail.
- **`tests/analysis/java/conftest.py`** (new): tests that patch `subprocess.run` never launch a JVM, so `ensure_jdk` is short-circuited for them and `JAVA_HOME` is restored after every test. The nine tests that run the real jar (entrypoints, CRUD, source-import disambiguation) keep the real lookup — they need a JDK by design and will download one **once** per project cache dir if no `$JAVA_HOME` with `jmods` exists; on the release runner `setup-graalvm` provides one, so CI downloads nothing.
- `CHANGELOG.md` `[Unreleased]` → `### Fixed`: two entries.

## Verification (macOS, empty `JAVA_HOME`)

- Before: `uv run pytest tests/analysis/java -q` → `12 failed, 125 passed, 4 skipped` (the ten, plus two real-jar entrypoint tests that fail order-dependently through the JDK re-download path above).
- After: `uv run pytest tests/analysis/java -q` → **`129 passed, 14 skipped`**, no archive or JDK tree created anywhere during the run.
- Exact release command `uv run pytest --pspec --cov=cldk --cov-fail-under=33 --disable-warnings` → **`613 passed, 184 skipped, 15 warnings in 304.39s`**, `Required test coverage of 33% reached. Total coverage: 75.60%`, exit 0.

Per #328's definition of done, the Linux/Python 3.11 confirmation can only come from an actual workflow run, i.e. the rc.2 tag itself.

## #255 / #256

Does not close either. This discharges #255's item 3 (source-analysis witnesses) and removes the `JAVA_HOME` leak it lists as the prime suspect for item 1 (Java suite order-dependence); items 2 (TS golden-fixture gating) and 4 (gate exercised on a scratch tag, and the fix mirrored to `main`) remain open. #256 is already closed as won't-fix; the formal removal of `source_code=` still belongs to the 2.0.0 breaking window.
