### PR TITLE
chore(release): 2.0.0-rc.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,6 +131,8 @@ jobs:
         with:
           files: dist/*
           body: ${{ steps.notes.outputs.notes }}
+          # An rc tag is a candidate, not the repository's latest release.
+          prerelease: ${{ contains(github.ref_name, '-rc') }}
           # Auto-open a repo-level Discussion linked to this release, seeded with
           # the same notes. Requires Discussions enabled and this category to exist.
           discussion_category_name: Announcements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v2.0.0-rc.2] - 2026-09-06
 Python legs 1, 1.5 and 1.6 of the CLDK 2.0 agent-facing query facade (see
 `docs/design/specs/2026-09-03-agent-facing-query-facade.md`,
 `docs/design/specs/2026-09-05-leg-1.5-bounded-queries-and-dataflow.md` and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cldk"
-version = "1.5.0"
+version = "2.0.0-rc.2"
 description = "The official Python SDK for Codellm-Devkit."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/uv.lock
+++ b/uv.lock
@@ -300,7 +300,7 @@ wheels = [
 
 [[package]]
 name = "cldk"
-version = "1.5.0"
+version = "2.0.0rc2"
 source = { editable = "." }
 dependencies = [
     { name = "codeanalyzer-python" },


### PR DESCRIPTION
Version bump for the first release candidate cut from `release/2.0`: legs 1 (#322), 1.5 (#323) and 1.6 (#330) on codeanalyzer-python 1.4.1, plus the release-gate fix (#329).

- `pyproject.toml` `1.5.0` → `2.0.0-rc.2`; `uv.lock` regenerated.
- `CHANGELOG.md`: `## [v2.0.0-rc.2] - 2026-09-06` wraps everything under `[Unreleased]` — the workflow refuses to publish without a heading matching the tag literally.
- `release.yml`: `prerelease: ${{ contains(github.ref_name, '-rc') }}` on the GitHub release step, so a candidate is not the repository's "Latest".

`2.0.0rc1` on PyPI came from the superseded #297 lineage and is being yanked. Merging this ships nothing; the tag `v2.0.0-rc.2` on the merge commit does.