### PR TITLE
ci(release): point codeanalyzer-python at the uv-installed interpreter

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,14 @@ jobs:
       - name: Install Python package dependencies
         run: uv sync --all-groups --frozen
 
+      # codeanalyzer-python provisions a virtualenv for the project it analyses and
+      # discovers a base interpreter for it (SYSTEM_PYTHON, else PATH/pyenv/conda/asdf).
+      # A uv-managed interpreter is on none of those on a runner, so every test that
+      # runs the real analyzer errored at setup (release run 34023739548). Point it
+      # at the interpreter uv just installed -- the override the analyzer documents.
+      - name: Point codeanalyzer-python at the analysis interpreter
+        run: echo "SYSTEM_PYTHON=$(uv python find 3.11)" >> "$GITHUB_ENV"
+
       - name: Run Tests
         id: test
         # continue-on-error is deliberate: without it a red suite fails the job


### PR DESCRIPTION
The `v2.0.0-rc.2` release run (`34023739548`) failed its test gate — `4 failed, 621 passed, 61 errors` — and deleted the tag, exactly as #306 intended. Nothing was published.

Every error is one cause, printed by the analyzer itself:

```
RuntimeError: Could not find a suitable base Python interpreter. Current environment:
/home/runner/work/python-sdk/python-sdk/.venv/bin/python (prefix: …/.venv). Please set the
SYSTEM_PYTHON environment variable to point to a working Python interpreter that can create
virtual environments.
```

codeanalyzer-python provisions a virtualenv for the project it analyses and discovers a base interpreter for it — `SYSTEM_PYTHON` if set, else `sys._base_executable`, `PATH`, pyenv, conda, asdf, each validated by running it. On the runner the uv-managed interpreter passes none of those, so every test that runs the real analyzer (the level-4 fixtures leg 1.5 introduced, which are also what lifted coverage over the gate) errored at setup. Locally the venv's base executable validates, which is why `686 passed / 0 failed` here under 3.11, 3.12 and 3.14 never reproduced it.

This adds one step before `Run Tests`: `SYSTEM_PYTHON=$(uv python find 3.11)` into `$GITHUB_ENV` — the override the analyzer documents. Verified locally: the same fixture that errors without a discoverable base passes with the override pointed at the uv-installed 3.11.

Workflow-only; the code tree is the gated `e712ecd`. The tag is re-cut on the merge commit.