### PR TITLE
docs: spec leg 2.5 — TypeScript to Python's leg-1.6 maturity

### DIFF
--- a/docs/design/specs/2026-09-06-leg-2.5-typescript.md
+++ b/docs/design/specs/2026-09-06-leg-2.5-typescript.md
@@ -1,0 +1,68 @@
+# Leg 2.5 — TypeScript to Python's leg-1.6 maturity
+
+**Status:** decided 2026-09-06. Epic: codellm-devkit/.github#55. Tracking: two work items on
+python-sdk (2.5a, 2.5b — filed just-in-time). Ships in `2.0.0-rc.3`.
+Facade decisions of record: `.claude/FACADE_DECISIONS.md` (TS-1 … TS-4).
+
+## 1. Contract-impact triage
+
+| Question | Answer |
+|---|---|
+| Does this change schema v2 output? | **No.** codeanalyzer-typescript emits canonical v2 (`schema_version 2.0.0`) at every level and projects a versioned Neo4j graph. This leg moves the **SDK** onto a schema major the analyzer already shipped. |
+| Change type | Schema v2 migration of one language's SDK layer + the facade surface leg 1.5/1.6 defined for Python. |
+| Repos | **python-sdk** (`cldk/models/typescript/`, `cldk/analysis/typescript/{backend,codeanalyzer,neo4j}`, pin, tests, `docs/agent-api-reference.md`). **docs** (agent reference has no TypeScript surface today). **No analyzer change** in this leg. |
+| Analyzer gates | codeanalyzer-typescript `main` (unreleased) closes every gap 1.2.0 left: #169 L4 port lattice wired to the DDG, #165 body-node/parameter ids, #166 `_module` retired / prefix-scoped destructive statements, entrypoint tiers (#160/#163/#168/#170). **2.5b pins the release that carries them (1.3.0) — never `main`.** |
+
+## 2. Where TypeScript stands (measured 2026-09-06)
+
+**Analyzer.** 1.2.0 (2026-09-03) emits the v2 envelope, `can://typescript/<app>/<file>/<Type>/<callable>` ids (JavaScript modules under `can://javascript/<app>/…`), `body{}` keyed `line:col` / `@entry` / `@exit` / `@formal_in:N` / `@formal_out` / `L:C/actual_in:N` / `L:C/actual_out`, split `cfg`/`cdg`/`ddg`/`summary`, call edges `{src,dst,prov,weight}` (`prov` ∈ `tsc`, `import`, `defuse`), application-scope `param_in`/`param_out`, artifacts, dependencies, config. Neo4j: 16 labels, 23 relationship types (`TS_HAS_MODULE`, `TS_DECLARES`, `TS_HAS_METHOD`, `TS_HAS_FIELD`, `TS_DECORATED_BY`, `TS_HAS_BODY_NODE`, `TS_RESOLVES_TO`, `TS_CALLS`, `TS_CFG_NEXT`, `TS_CDG`, `TS_DDG`, `TS_SUMMARY`, `TS_PARAM_IN`, `TS_PARAM_OUT`, `TS_EXTENDS`, `TS_IMPLEMENTS`, `TS_UNRESOLVED_IMPORT`, `TS_USES_CONFIG`, `TS_PROVIDES`, and the shared `HAS_ARTIFACT`, `DECLARES_DEPENDENCY`, `LOCKS`, `DEFINES_CONFIG`); anchor `:Application:TSApplication {id}` carrying `analyzer_name`, `analyzer_version`, `schema_version`, `max_level`, `k_limit`; merge label `CanNode` with a uniqueness constraint on `id`. On `main`: the L4 lattice is connected (measured on `test/fixtures/dataflow-app`: `formal_in→*` 43, `*→actual_in` 15, `actual_out→*` 18), body nodes and parameters carry `id`, `_module` is gone.
+
+**SDK.** `release/2.0` pins `codeanalyzer-typescript==0.4.3` — schema **1.0.0**, eight releases and two majors behind. `cldk/models/typescript/models.py` is the v1 identity-only mirror (`extra="forbid"`; no envelope, no `id`, no `span`, no `body`/`cfg`/`cdg`/`ddg`/`summary`, no `param_in`/`param_out`, no artifacts; call edges are `{source,target,type,weight,provenance,tags}`). `TSCodeanalyzer` passes `--tsc-only`, a flag removed at 1.0.0, and only ever asks for `-a 1`/`-a 2`. `TSNeo4jBackend` queries `:Symbol`/`:CallSite`/`:CALLS`/`:HAS_CALLSITE` — **zero overlap** with the v2 vocabulary — and scopes on `_module`. `TSAnalysisBackend` never inherited the generic `AnalysisBackend`. **Nothing on `release/2.0` can read a 1.2.0 artifact.** Details: the leg-1.5 ledger, "B GAP ANALYSIS".
+
+## 3. Decisions
+
+| # | Decision | Why |
+|---|---|---|
+| **G1** | **Per-language v2 models, hand-written.** `cldk/models/typescript/` becomes a pydantic mirror of cants' `src/schema/schema.ts` at the pinned release — envelope, `TSApplication{id, kind, symbol_table, call_graph, external_symbols, synthesized_callables, param_in, param_out, artifacts, dependencies, unresolved_imports, entrypoint_report, config_uses, config_reads}`, `TSModule` with unified `types{}` keyed by `kind`, `TSCallable{id, span, body, cfg, cdg, ddg, summary, …}`, `TSBodyNode{id, kind, span, callee, …}`, `TSCallEdge{src,dst,prov,weight}`. The 1.x model's TS facets (`is_exported`, `is_async`, `accessibility`, `overload_signatures`, `type_parameters`, `TSField`) are kept where the v2 schema still emits them. | Leg-1 **D2**: no shared declaration models; each language models its own tree. The canonical `cldk/models/cpg/` stranded on the #297 lineage is not revived. |
+| **G2** | **`TSAnalysisBackend` inherits `AnalysisBackend[TSApplication, TSModule, TSType, TSCallable, TSField, str]` with `P = "TS"`, `N = "TS"`.** Everything Python put on its language ABC that is not Python-shaped moves to the generic ABC in the same change: `locate`/`locate_many`, `resolve_callable`/`resolve_value`, the scoping keywords, `get_cfg`/`get_cdg`/`get_ddg`, the slices/reachability/path family, `describe`, `get_source`, `has_resolution_edges`, the entrypoint and external accessors. Java keeps its own ABC until leg 2. | Leg-1 **D3**: one generic ABC in three families. The second implementation is what earns a method its place on the shared ABC — the ABC's own docstring says so. |
+| **TS-1** | **`LocateResult` goes language-neutral.** Its Python-typed body-node field becomes `BodyRef{id, kind, span, callee}` (shared `Span`), populated from either analyzer. `node_id`, `module`, `callable`, `diagnostics` unchanged. | One result type per question. `TSLocateResult` (two types) and dropping the node (an extra round trip for the commonest question) were rejected. |
+| **TS-2** | **The full dataflow surface ships in 2.5b on cants ≥ 1.3.0.** `slice_backward`/`slice_forward`/`backward_cone`/`reaches`/`callers_of`/`callees_of`/`paths_between`/`call_paths_between`/`flows_to_call`/`flows_to_argument`/`describe`, with Python's semantics (depth default 5 on slices only; predicates and paths unbounded; completeness protocol; E8 no suggestions). The version probe refuses a graph whose `analyzer_version` predates the lattice fix. | The gap that would have forced an intraprocedural-only compromise (#80/#81) is closed on `main`; the SDK waits for the cut rather than shipping against an unreleased build (lockstep). |
+| **TS-3** | **JavaScript modules are in scope.** Application scope is a **list of two prefixes**, `can://typescript/<app>/` and `can://javascript/<app>/`; every scoping statement, the multi-application audit, `module_key_of`'s known-key set and the fake driver take the list. `module_key_of` accepts `.ts/.tsx/.js/.jsx/.mjs/.cjs` keys — by verified longest match, as F4 requires, never by extension splitting. | cants already emits them in the same graph; a single-prefix port would silently drop every `.js` module (D7). python-sdk #307 folds into this leg's scope statement. |
+| **TS-4** | **Two work items under #55, both on `2.0.0-rc.3`.** **2.5a — TypeScript on schema v2:** G1, G2's inheritance, both backends re-pointed at the 1.2.0 vocabulary, pin `1.2.0`, schema probe (relationship-type floor + `analyzer_version`), prefix scoping (TS-3), the existing accessors — Tier A, the 1.x leaf accessors, the four #302 bulk accessors — green on the live superset graph; the generic helpers lifted out of `python/backend.py` into `commons/` on the way. **2.5b — the query surface to leg-1.6 parity:** TS-1, TS-2, scoping keywords, per-callable `EdgePage`s, entrypoints, artifact/config layer, `SelectorNotInGraph`/`AmbiguousName`, the agent reference's TypeScript section; pin bumped to `1.3.0` when cut. 2.5b is filed when 2.5a lands. | Tracking follows PR granularity: a model/backend rewrite and a surface port are two PRs. Both belong to one train because neither is useful alone. |
+| **G3** | **Tier A and the 1.x TypeScript leaf accessors are invariant.** `get_interfaces`, `get_enums`, `get_enum_members`, `get_type_aliases`, `get_namespaces`, `get_functions`, `get_exports`, `get_variables`, `get_interface_properties`, `get_implemented_interfaces`, `get_class_hierarchy`, the decorator family, `get_synthesized_callables`, `get_call_sites`, `get_calling_lines`, `get_call_targets` keep names, signatures and return types. Accessors that only ever raised `NotImplementedError` (`get_entry_point_methods`, `get_service_entry_point_methods`) are replaced by the working `get_entrypoints`/`get_entrypoint_classes`/`get_entrypoint_coverage` — the same treatment Python's fifteen got in leg 1. | The rung's Iron Rule; leg-1 D4. |
+| **G4** | **Lift before port.** `check_depth`, `check_max_nodes`, `check_max_paths`, `check_page_size`, `check_distinct_endpoints`, `reject_bare_string`, `check_selector`, `scope_paths`, `resolve_module_key`, `call_graph_scope`, `bounded_subgraph`, `EdgeOrder`/`edge_page`, the cursor codec, `hop_sort_key`, `flow_path` (parameterised on the `VIA` map), `slice_resolved`, `cone_sinks`, `as_slice_node`, `module_key_of` (parameterised on the known-key set), and the `SDG_RELS`/`VIA` tables (parameterised on `P`) move from `cldk/analysis/python/backend.py` and `python/neo4j/reconstruct.py` into `cldk/analysis/commons/` in 2.5a, with Python re-importing them — a pure move, pinned by Python's existing 686 tests. `module_dotted` takes the extension set as a parameter. | ~450 lines that contain nothing Python-specific except three items. Porting by copy would fork the leg-1.6 rulings; Java (leg 2) needs the same lift. |
+| **G5** | **The probe is generation-aware from day one.** `_probe_schema`: required relationship types (`TS_HAS_MODULE`, `TS_HAS_METHOD`, `TS_HAS_BODY_NODE`, `TS_CALLS`), `:Application` with the requested id, `analyzer_version` parsed; below the floor → `GraphSchemaMismatch` naming found and required. 2.5a's floor is `1.2.0`; 2.5b raises it to the release carrying #169/#165/#166. A graph emitted by an unreleased `main` stamped `1.2.0` is indistinguishable from a real 1.2.0 graph — filed upstream; until fixed, the SDK cannot tell them apart and says so in the reference. | Leg-1.6 F2; the codeanalyzer-python 1.4.1 lesson (`_module` vanished under an unchanged probe). |
+
+## 4. What a caller sees
+
+Nothing existing moves (G3). New on `TypeScriptAnalysis`, method-for-method with `PythonAnalysis`: the addressing, scoping, per-callable graph, slice/reachability/path, `describe`, entrypoint, artifact/config and external accessors; the same result types (`SliceNode`, `EdgePage`, `Slice`, `FlowPaths`, `LocateResult` with `BodyRef`, `Diagnostic`, `EntrypointCoverage`) and the same exceptions. Path values are repo-relative module keys with their real extension (`src/pages/Home.tsx`); `SliceNode.defined_in` carries the module's dotted-less key form the TS analyzer uses.
+
+Behaviour changes a 1.x caller must know: the pin moves `0.4.3 → 1.2.0` (2.5a) `→ 1.3.0` (2.5b); a graph emitted by codeanalyzer-typescript `< 1.2.0` is refused at attach (it was served with silent empties); the two removed raising accessors.
+
+## 5. Verification environment
+
+| container | bolt | emitted by | role |
+|---|---|---|---|
+| `cldk-leg25-it` | 7690 | codeanalyzer-typescript **`main` source build** (`977198e`), superset-frontend (2,184 `.ts/.tsx`) | primary until 1.3.0 is cut, then re-emitted with the 1.3.0 wheel |
+| `cldk-leg16-it` | 7689 | codeanalyzer-python 1.4.1, odoo-slim-19 | Python regression gate for G4's lift |
+
+The 1.2.0 wheel's compiled binary cannot start its dataflow workers (`$bunfs` worker resolution — filed upstream) and falls back to sequential extraction; it still produces the graph. thingsboard `ui-ngx` (1,487 files, Angular, multi-tsconfig) is the corpus for cants#94 and is run once before any L3/L4 claim in 2.5b. Port 7687 on the development machine is an ssh tunnel and is never a target.
+
+## 6. Release plan
+
+1. **2.5a** → PR to `release/2.0`; pin `codeanalyzer-typescript==1.2.0`. Gate: offline suite, Python live suite on 7689 unchanged after the lift, TypeScript live suite on 7690 for every existing accessor, contract tests for both languages.
+2. **Maintainer cuts codeanalyzer-typescript 1.3.0** (#169, #165, #166, entrypoints, the version stamp). The SDK pins only released analyzers.
+3. **2.5b** → PR to `release/2.0`; pin `1.3.0`; 7690 re-emitted with the wheel. Gate: the leg-1.6 suite's TypeScript twin green live, including the multi-application audit over every statement, the ghost rule, the completeness protocol, byte-identical path values between the source-build graph and the 1.3.0 graph for the same callable.
+4. **`chore(release): 2.0.0-rc.3`** → tag → announcement.
+
+## 7. Out of scope
+
+Java (leg 2, #310). The cross-language query sweep (leg 4 / 2.0.0). Analyzer work of any kind — cants #94, #95 (prefixing the bare `CanNode`/`Application` merge labels; when it lands, the SDK's label references change in a maintenance PR, not here), #54, #57, #59/#300, #87. TypeScript-SDK (`typescript-sdk` repo) mirroring of this surface.
+
+## 8. Definition of done (leg)
+
+- Every accessor on `PythonAnalysis` that is not Python-shaped exists on `TypeScriptAnalysis` with the same name, signature, return type and exceptions; the contract test asserts both backends implement every generic-ABC method.
+- `python/backend.py` retains only Python-shaped code; Python's suite is unchanged in count and green on 7689.
+- The TypeScript live suite passes on 7690 against the 1.3.0-emitted superset graph, including a multi-application audit that enumerates every statement on `TSNeo4jBackend`.
+- Attaching to a `0.4.3`-emitted graph raises `GraphSchemaMismatch`; attaching as an absent application raises it too.
+- `docs/agent-api-reference.md` documents TypeScript as a first-class surface with its version floor and JavaScript scope.


### PR DESCRIPTION
Part of codellm-devkit/.github#55. Docs only: the leg 2.5 spec and the facade decisions of record.

Spec: `docs/design/specs/2026-09-06-leg-2.5-typescript.md`. Decisions: `.claude/FACADE_DECISIONS.md`.

**Triage.** No schema change — codeanalyzer-typescript emits canonical v2 at every level and projects a versioned Neo4j graph. The SDK's TypeScript layer on `release/2.0` is the v1 identity-only mirror pinned to `0.4.3` (schema 1.0.0): it passes a flag removed at 1.0.0, parses with an `extra="forbid"` v1 model, and its Neo4j backend queries a vocabulary with zero overlap with what the analyzer writes. Nothing on `release/2.0` can read a 1.2.0 artifact.

**Decisions.** Per-language v2 models (G1); `TSAnalysisBackend` inherits the generic ABC and every non-Python-shaped method moves onto it (G2); `LocateResult` gets a language-neutral `BodyRef` (TS-1); the full dataflow surface ships on codeanalyzer-typescript ≥ 1.3.0, whose `main` already connects the L4 port lattice (#169), stamps body-node ids (#165) and retires `_module` (#166) — verified (TS-2); JavaScript modules are in scope as a second id prefix per application (TS-3); two work items under the epic, both on `2.0.0-rc.3` (TS-4); Tier A and the 1.x leaf accessors are invariant (G3); the ~450 language-neutral helper lines in `python/backend.py` lift to `commons/` before anything is ported (G4); the schema probe is generation-aware from day one (G5).

**Release plan.** 2.5a (models, backends, pin 1.2.0) → maintainer cuts cants 1.3.0 → 2.5b (query surface, pin 1.3.0) → `chore(release): 2.0.0-rc.3`.

Filed upstream while assessing: codeanalyzer-typescript #171 (1.2.0 wheel's compiled binary cannot start its dataflow workers; `-j` silently sequential) and #172 (`main` stamps `analyzer_version 1.2.0` on post-1.2.0 graphs).