### PR TITLE
docs: spec leg 3 — Java to Python's leg-1.6 maturity

### DIFF
--- a/docs/design/specs/2026-09-06-leg-3-java.md
+++ b/docs/design/specs/2026-09-06-leg-3-java.md
@@ -1,0 +1,75 @@
+# Leg 3 — Java to Python's leg-1.6 maturity
+
+**Status:** decided 2026-09-06. Epic: codellm-devkit/.github#55. Tracking: two work items on
+python-sdk — #310 (3a) and #311 (3b). Ships in `2.0.0-rc.4`.
+Facade decisions of record: J-1 … J-12 below (working log in `.claude/FACADE_DECISIONS.md`).
+
+## 1. Contract-impact triage
+
+| Question | Answer |
+|---|---|
+| Does this change schema v2 output? | **No.** codeanalyzer-java 3.0.1 (2026-09-03) emits canonical v2 (`schema_version 2.0.0`) at L1–L4 and projects a full-depth, versioned Neo4j graph. This leg moves the **SDK** onto what the analyzer already emits. |
+| Change type | Schema-v2 migration of one language's SDK layer + the facade surface legs 1.5/1.6 defined for Python. |
+| Repos | **python-sdk** only: `cldk/models/java/`, `cldk/analysis/java/{backend,codeanalyzer,neo4j}`, pin + bundled jar, tests, `docs/agent-api-reference.md`, `CLAUDE.md` table. |
+| Analyzer follow-ons (not gates) | codeanalyzer-java #187 (CRUD in v2), `k_limit` not emitted, no `entrypoint_report`/`repository` stamp, #215 (`declaration`), #182 stale (L4 overlay is emitted). |
+
+## 2. Where Java stands (measured 2026-09-06)
+
+**Analyzer.** 3.0.1 on daytrader8 (`-a 4`): envelope `{schema_version 2.0.0, language, max_level, analyzer}` (no `k_limit`); `application {id can://java/daytrader8, kind, symbol_table 138, call_graph 1,862, param_in 1,932, param_out 909, artifacts, dependencies}`; modules carry `package`, `source`, structured `imports` with spans; types carry one `kind` (class/interface/enum/annotation/record), `decorators`, `base_types`, `interfaces`, `fields`, `callables` keyed by `signature` with the erased parameter tail (`cancelOrder(java.lang.Integer, boolean)`), nested `types`; callables carry `body`/`body_span`/`cfg`/`cdg`/`ddg`/`summary`/`decorators`/`error_channel`/`metrics`/`local_variables`/`refs`/`is_entrypoint`/`is_implicit`; `ddg.prov ∈ {ssa, points-to}`; call edges `{src, dst, prov ⊆ {declared, rta}, weight}`. Initializers are callables (`<clinit>$0()`, kind `initializer`); implicit callables (92) have no span or body; anonymous classes appear as `…/Type/$anon$0/…` (ThingsBoard). `declaration` is `None` (#215).
+
+`--emit neo4j` (forces L4 + external calls) on daytrader8: 18,354 nodes / 53,319 rels. Labels `JCanNode` (marker), `JSymbol`, `JCallable`, `JExternal`, `JBodyNode`, `JVariable`, `JField`, `JType`, `JModule`, `JAnnotation`, `JEntrypoint`, `JPackage`, `Artifact`, `ConfigKey`, `Package`, `JApplication`. Relationships `J_HAS_MODULE`, `J_DECLARES`, `J_HAS_METHOD`, `J_HAS_FIELD`, `J_DECLARES_VAR`, `J_HAS_BODY_NODE`, `J_CALLS`, `J_RESOLVES_TO`, `J_CFG_NEXT`, `J_CDG`, `J_DDG`, `J_SUMMARY`, `J_PARAM_IN`, `J_PARAM_OUT`, `J_IMPORTS`, `J_ANNOTATED_BY`, `J_EXTENDS`, `J_IMPLEMENTS`, `HAS_ARTIFACT`, `DEFINES_CONFIG`, `DECLARES_DEPENDENCY`. Anchor `:JApplication {name, schema_version, analyzer_name, analyzer_version}` — keyed by **name**. `JModule {id, file_key, package, content_hash}`. Body-node ids `<callable id>@line:col`; call body nodes carry `receiver_type`, `receiver_expr`, `method_name`, `accessibility`, `is_static_call`, `return_type`. No `_module` property anywhere. ThingsBoard v4.0 (4,131 units) emits in 7 min with `--no-build`: 598,413 nodes / 1,355,741 rels; 28,763 callables; 496,821 body nodes.
+
+**SDK.** `release/2.0` pins and bundles `codeanalyzer-java 2.4.1` (v1 output; `--schema v1` still exists in 3.0.1 but is not the default). `cldk/models/java/models.py` is v1: no envelope, no `id`, no `span`, no `extra=` policy (a v2 envelope is silently discarded), rich `JGraphEdges` with a module-global `_CALLABLES_LOOKUP_TABLE`. `JavaAnalysisBackend` is a plain ABC (36 v1 methods, no `P`/`N`). `JNeo4jBackend` scopes by `_module` at six sites, has no probe, reads `:JCompilationUnit`/`J_HAS_UNIT` and `<fqn>#<signature>` ids — none of which 3.0.1 writes. `get_call_graph()` keys nodes by `(signature, klass)` tuples. Eight facade accessors raise `NotImplementedError`. `source_code` single-file mode is half-retired (#328). Fixtures are 2.3.7. The Neo4j docstring claims codeanalyzer-java #157/#158 fixed in 2.4.1; both are open (against the v1 graph the SDK stops reading).
+
+Related: python-sdk #336/#337 — the release workflow bundled `releases/latest` regardless of the pin (rc.2 shipped both jars); fixed ahead of this leg so the 3.0.1 pin is authoritative when it moves.
+
+## 3. Decisions
+
+| # | Decision | Why |
+|---|---|---|
+| **J-1** | **`get_call_graph()` nodes are keyed by the string `<type fqn>.<signature>`** (e.g. `com.ibm.websphere.samples.daytrader.impl.direct.TradeDirect.cancelOrder(java.lang.Integer, boolean)`), replacing `(signature, klass)`. Edge attrs `type`/`weight`/`calling_lines` stay. | Every string-addressed helper (`bounded_subgraph`, `roots=`, `SliceNode.ref`, `describe`) needs strings; #310 already sanctions the node-key shift; E6 keeps `can://` out of the surface. Unique per application because the parameter tail splits overloads. |
+| **J-2** | **Module key = repo-relative path; dotted vocabulary = `module.package`.** `in_module=` accepts a path suffix or a dotted package (optionally `.TypeName`). Java gets its own `module_dotted` that reads `package`; the commons helper is never called with a Java path. `JCompilationUnit` keeps its name. | A Java file is a compilation unit: path + declared package + N types. Deriving the dotted name from the path yields `src.main.java.…` — wrong, silently. |
+| **J-3** | **`resolve_callable(name)` matches the simple name with the parameter tail stripped; overloads raise `AmbiguousName` listing the full signatures; spelling `name(erased types)` resolves exactly. No `params=` keyword.** | 15 overloaded names in daytrader8 alone; `in_class=`/`in_module=` cannot split an overload pair; E8 already says ambiguity raises with candidates and nothing fuzzy. |
+| **J-4** | **CRUD accessors keep their names and raise on v2 payloads, naming codeanalyzer-java #187.** `get_all_entry_point_methods/classes` stay; `get_entrypoints`, `get_entrypoint_classes`, `get_entrypoint_coverage` are added in Python's shapes; coverage reports `entrypoint_report_unavailable`. | Iron Rule forbids removal; D7 forbids an ambiguous empty. Java emits `is_entrypoint` booleans, no report. |
+| **J-5** | **`get_decorated_callables(markers)`: a marker matches by simple name (`Test`), with a leading `@` ignored (`@Test`), or by exact fully-qualified name (`org.junit.Test`).** Neo4j serves it via `J_ANNOTATED_BY`. | A filter, not an address — package ambiguity is acceptable here; one vocabulary across languages. |
+| **J-6** | **Whatever the analyzer emits as a callable is addressable.** Initializers resolve and get graphs/slices; implicit callables resolve but `get_source`/`get_cfg`/`get_cdg`/`get_ddg`/slices raise naming the reason; anonymous classes (`$anon$N`) follow the same rule. The SDK invents no callables. | Implicit constructors are call-graph endpoints; hiding them dangles edges. |
+| **J-7** | **New leaf accessors `get_interfaces`, `get_enums`, `get_enum_members`, `get_records`.** Annotation types remain reachable through `get_classes`. | Names shared with TypeScript (G3) plus the one Java-only kind that exists (35 records in ThingsBoard). |
+| **J-8** | **Rich v1 fields become computed views over the v2 models** (#310's two-layer plan): `JCallable.code` = span slice of the module `source`; `.call_sites` = `JCallSite` views over call body nodes; `.thrown_exceptions` ← `error_channel`; `.cyclomatic_complexity` ← `metrics`; `.variable_declarations` ← `local_variables`; `.referenced_types`/`.accessed_fields` ← `refs`; `declaration` is `None` until #215. Models set `extra="forbid"`. | Same names, same types, no analyzer work, no duplicated blob. |
+| **J-9** | **Floor codeanalyzer-java 3.0.1.** Neo4j `_probe_schema` requires `J_HAS_MODULE`, `J_HAS_METHOD`, `J_HAS_BODY_NODE`, `J_CALLS`, reads `analyzer_version` off `:JApplication {name}`, raises `GraphSchemaMismatch` below 3.0.1 or on a v1 graph. Local: a cached `analysis.json` without `schema_version` is refused with a re-run message. Pin and bundled jar `3.0.1`. | 3.0.0 stamped contract 2.2.0; 3.0.1 holds 2.0.0 — one contract to reason about. Leg 1.6's rule: silent partials on an old graph are the failure mode. |
+| **J-10** | **`source_code` single-file mode is removed** (ctor param, `_codeanalyzer_single_file`, facade guards); `get_test_methods` reads module `source`. Listed as a 2.0 breaking change; the 10 skip-gated witnesses retire. | Won't-fix upstream (#256); 2.0 is the major that can drop it. |
+| **J-11** | **Two work items under #55: #310 = 3a, #311 = 3b** (see §6). Existing issues rebodied; spec linked. | Tracking follows PR granularity; the analyzer is already released, so no wait between halves. |
+| **J-12** | **Both ship in `2.0.0-rc.4`**, after rc.3 (TypeScript). | One Java prerelease, one announcement for the sanctioned shifts. |
+
+Scoping follows leg 1.6 verbatim: application scope is the single prefix `can://java/<app>/`; every Neo4j statement is prefix-scoped; the multi-application audit (F7) runs over daytrader8 + ThingsBoard in one graph. `P = "J"`, `N = "J"` (relationships `J_*`, labels `:J*`); the `:JCanNode` marker is used only where measured faster per label (leg 2.5's per-label seek rule).
+
+## 4. What a caller sees
+
+Nothing existing moves except the two sanctioned shifts: call-graph node keys (J-1) and the removal of `source_code` (J-10). CRUD accessors raise instead of returning stale data on v2 (J-4). New on `JavaAnalysis`, method-for-method with `PythonAnalysis`: `get_symbol_table(paths=)`, `get_call_graph(roots=, depth=)`, `get_imports`, `get_callables_overview`, `get_method_bodies`, `get_decorated_callables`, `get_entrypoints`/`get_entrypoint_classes`/`get_entrypoint_coverage`, `has_resolution_edges`, `get_callsites_for`, `get_external_symbols`, `locate`/`locate_many`, `resolve_callable`, `resolve_value`, `get_source`, `get_cfg`/`get_cdg`/`get_ddg`, `slice_backward`/`slice_forward`, `reaches`, `backward_cone`, `callers_of`/`callees_of`, `paths_between`/`call_paths_between`, `flows_to_call`/`flows_to_argument`, `describe`, `get_artifacts`/`get_dependencies`/`get_config_keys`/`get_config_uses`/`get_unresolved_config_reads`/`get_config_readers`, `get_classes(module=)`, and the J-7 leaf accessors. The eight `NotImplementedError` raisers are retired: `get_imports`, `get_variables`, `get_class_hierarchy`, `get_methods_with_annotations` (→ alias of `get_decorated_callables`), `get_calling_lines`, `get_call_targets` implemented over v2; `get_service_entry_point_*` deleted (never implemented, no data).
+
+## 5. Verification environment
+
+| container | bolt | emitted by | role |
+|---|---|---|---|
+| `cldk-leg3-it` | 7691 | codeanalyzer-java 3.0.1 `--emit neo4j`: daytrader8 (18,354 nodes) **and** thingsboard v4.0 (598,413 nodes, `--no-build`) | primary; two applications in one graph for the scoping audit; ThingsBoard is the scale gate (timing ceilings measured here) |
+| `cldk-leg16-it` | 7689 | codeanalyzer-python 1.4.1, odoo-slim-19 | Python regression gate for anything touched in `commons/` |
+
+Containers live in the `podman` docker context. JSON reference: daytrader8 `-a 4` (22.5 MB). The JDK comes from the SDK's own `ensure_jdk` (Temurin 21.0.5+11 with jmods). New fixtures: a 3.0.1 `analysis.json` for daytrader8 at `-a 1` and `-a 4` (generated, checked in under `tests/resources/java/analysis_json/v2/`); the 2.3.7 fixtures retire with the v1 models.
+
+## 6. Release plan
+
+1. **3a (#310) — Java on schema v2.** v2 models + views (J-8), `JavaAnalysisBackend` inherits `AnalysisBackend[JApplication, JCompilationUnit, JType, JCallable, JField, JCallableParameter]`, `JCodeanalyzer` drives 3.0.1 at L1–L4 (`analysis_level` reaches `-a`), `JNeo4jBackend` re-pointed at the 3.0.1 vocabulary with prefix scoping and the J-9 probe, string node keys (J-1), pin + jar 3.0.1, `source_code` removed (J-10), CRUD raisers (J-4), fixtures regenerated. Gate: offline suite; live parity suite on 7691 for every existing accessor; Python live suite on 7689 unchanged. PR → `release/2.0`.
+2. **3b (#311) — the leg-1.5/1.6 surface for Java.** Everything in §4 not delivered by 3a, on both backends; the multi-application audit over every statement; timing ceilings on ThingsBoard; `docs/agent-api-reference.md` Java section. PR → `release/2.0`.
+3. **`chore(release): 2.0.0-rc.4`** → tag → announcement (sanctioned shifts first).
+
+## 7. Out of scope
+
+Analyzer work of any kind: CRUD in v2 (#187), `k_limit`, `entrypoint_report`, `declaration` (#215), #157/#158 (v1 graph). The cross-language query sweep (leg 4 / 2.0.0). Go and C++ legs.
+
+## 8. Definition of done (leg)
+
+- Every accessor in §4 answers identically on `JCodeanalyzer` and `JNeo4jBackend` over daytrader8, with the same diagnostics on the miss paths (raise naming what missed; no suggestions).
+- Public-surface test freezes every pre-existing accessor's name, signature and return type except the two sanctioned shifts, each documented in `CHANGELOG.md` with a one-line migration.
+- `GraphSchemaMismatch` on a v1 graph and on `analyzer_version < 3.0.1`; a v1 `analysis.json` cache refused with a re-run message.
+- Multi-application audit green with daytrader8 and ThingsBoard in one graph; no statement without the prefix.
+- Timing ceilings measured on ThingsBoard for `locate`, `resolve_callable`, `get_cfg`, `slice_backward`, `callers_of` (recorded in the plan, not guessed).
+- `CLAUDE.md` table row for Java updated; agent reference has a Java section.


### PR DESCRIPTION
Design record for leg 3 (Java) under epic codellm-devkit/.github#55: `docs/design/specs/2026-09-06-leg-3-java.md`.

Triage: no schema v2 change — codeanalyzer-java 3.0.1 already emits canonical v2 at L1–L4 and a full-depth Neo4j projection (measured live on daytrader8 and ThingsBoard v4.0); this leg moves the SDK onto it. Single repo.

Decisions J-1…J-12 in §3. Tracking: #310 = 3a (models, ABC, both backends, probe, pin, `source_code` removal, CRUD raisers), #311 = 3b (the leg-1.5/1.6 surface for Java). Both ship in 2.0.0-rc.4.

Docs only; no code changes.