### PR TITLE
ci(release): build the release body from install + assets, not the changelog

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,26 @@
+# Configures GitHub's auto-generated release notes — the "What's Changed" section
+# appended by `generate_release_notes` in .github/workflows/release.yml. Merged PRs
+# are grouped under these emoji headings by label, matching the sibling analyzer
+# repositories so a reader sees one shape across the org.
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - github-actions
+  categories:
+    - title: 🚀 Features
+      labels: [enhancement, kind/feature]
+    - title: 🐛 Fixes
+      labels: [bug, fix]
+    - title: ♻️ Refactoring
+      labels: [refactoring]
+    - title: ⚡️ Performance
+      labels: [performance]
+    - title: 📚 Documentation
+      labels: [documentation, doc]
+    - title: 🚦 Tests
+      labels: [test]
+    - title: 🚨 Breaking Changes
+      labels: [breaking]
+    - title: 🛠 Other Changes
+      labels: ["*"]

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -8,6 +8,10 @@ changelog:
       - dependabot
       - github-actions
   categories:
+    # Order matters: a PR lands in the FIRST category whose label it carries, so a
+    # breaking fix must be seen as breaking before it is seen as a fix.
+    - title: 🚨 Breaking Changes
+      labels: [breaking]
     - title: 🚀 Features
       labels: [enhancement, kind/feature]
     - title: 🐛 Fixes
@@ -20,7 +24,5 @@ changelog:
       labels: [documentation, doc]
     - title: 🚦 Tests
       labels: [test]
-    - title: 🚨 Breaking Changes
-      labels: [breaking]
     - title: 🛠 Other Changes
       labels: ["*"]

--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -1,0 +1,51 @@
+name: Label pull requests
+
+# The release notes group merged PRs by label (.github/release.yml). Every PR in this
+# repository has historically been unlabelled, so without this every entry would land in
+# the catch-all "Other Changes" heading and a breaking change would read like a chore.
+# Titles here follow conventional commits already, so the label is derivable rather than
+# something a human has to remember.
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply a label from the conventional-commit prefix
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TITLE: ${{ github.event.pull_request.title }}
+          NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # A "!" before the colon marks a breaking change in conventional commits
+          # (feat(python)!: ...). That wins over the type, because a breaking fix is
+          # first of all breaking.
+          if printf '%s' "$TITLE" | grep -qE '^[a-z]+(\([^)]*\))?!:'; then
+            label=breaking
+          else
+            type=$(printf '%s' "$TITLE" | sed -nE 's/^([a-z]+)(\([^)]*\))?:.*/\1/p')
+            case "$type" in
+              feat)              label=enhancement ;;
+              fix)               label=fix ;;
+              perf)              label=performance ;;
+              refactor)          label=refactoring ;;
+              docs)              label=documentation ;;
+              test)              label=test ;;
+              ci|build|chore)    label=other ;;
+              *)                 label="" ;;
+            esac
+          fi
+          if [ -z "$label" ]; then
+            echo "::notice::'$TITLE' has no conventional-commit type; leaving it unlabelled (it will appear under Other Changes)."
+            exit 0
+          fi
+          echo "Labelling #$NUMBER as '$label'."
+          gh pr edit "$NUMBER" --repo "$REPO" --add-label "$label"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,15 +140,58 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           echo "Release notes for $version:"; echo "$notes"
 
+      # The release body is install one-liners plus a download table; the categorized
+      # "What's Changed" (merged PRs grouped under emoji headings via .github/release.yml)
+      # is appended by generate_release_notes below. The hand-written CHANGELOG section
+      # stays the ANNOUNCEMENT's seed rather than the release body: a changelog entry
+      # explains a change to a maintainer, a release body tells a user what to install.
+      # Indented code blocks avoid backticks inside the heredoc.
+      - name: Compose release notes header (install + download)
+        run: |
+          set -euo pipefail
+          REPO="codellm-devkit/python-sdk"
+          TAG="${GITHUB_REF#refs/tags/}"          # e.g. v2.0.0-rc.2
+          VERSION="${TAG#v}"                      # 2.0.0-rc.2
+          # PyPI normalizes 2.0.0-rc.2 to 2.0.0rc2, and the built artifacts carry the
+          # normalized spelling, so the install line and the asset links must use it.
+          # Done with sed rather than packaging.version: this runs on the runner's bare
+          # python3, which is not the uv-managed environment the tests use.
+          PV=$(printf '%s' "$VERSION" \
+                | sed -E 's/-?alpha\.?([0-9]+)/a\1/; s/-?beta\.?([0-9]+)/b\1/; s/-(rc|a|b)\.?([0-9]+)/\1\2/')
+          BASE="https://github.com/${REPO}/releases/download/${TAG}"
+          PRE=""
+          case "$PV" in *rc*|*a*|*b*) PRE="--pre " ;; esac
+          cat > "$RUNNER_TEMP/RELEASE_BODY.md" <<EOF
+          ## Install cldk ${TAG}
+
+          PyPI:
+
+              pip install ${PRE}cldk==${PV}
+
+          With the read-only Neo4j backend:
+
+              pip install ${PRE}'cldk[neo4j]==${PV}'
+
+          ## Download
+
+          | File | Description |
+          | --- | --- |
+          | [cldk-${PV}-py3-none-any.whl](${BASE}/cldk-${PV}-py3-none-any.whl) | Python wheel |
+          | [cldk-${PV}.tar.gz](${BASE}/cldk-${PV}.tar.gz) | Source distribution |
+          EOF
+          echo "----- composed header -----"; cat "$RUNNER_TEMP/RELEASE_BODY.md"
+
       - name: Publish Release on GitHub
         uses: softprops/action-gh-release@v2
         with:
           files: dist/*
-          body: ${{ steps.notes.outputs.notes }}
+          body_path: ${{ runner.temp }}/RELEASE_BODY.md
+          generate_release_notes: true   # categorized "What's Changed"; see .github/release.yml
           # An rc tag is a candidate, not the repository's latest release.
           prerelease: ${{ contains(github.ref_name, '-rc') }}
-          # Auto-open a repo-level Discussion linked to this release, seeded with
-          # the same notes. Requires Discussions enabled and this category to exist.
+          # Auto-open a repo-level Discussion linked to this release, seeded with this
+          # body. Requires Discussions enabled and this category to exist. The prose
+          # announcement is curated afterwards (see CLAUDE.md).
           discussion_category_name: Announcements
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-<img src="https://github.com/codellm-devkit/.github/blob/main/profile/assets/cldk-dark.png" alt="Codellm-Devkit logo">
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/codellm-devkit/.github/main/profile/assets/cldk-dark.png">
+  <img src="https://raw.githubusercontent.com/codellm-devkit/.github/main/profile/assets/cldk-light.png" alt="Codellm-Devkit logo">
+</picture>
 
 <p align='center'>
   <a href="https://arxiv.org/abs/2410.13007">


### PR DESCRIPTION
The release body was the `CHANGELOG.md` section verbatim, so a maintainer-facing entry became the user-facing release notes. Across five releases that produced three different shapes and two failures:

| release | published body |
|---|---|
| v1.4.2, v1.4.3 | a raw PR-title dump, `chore(release)` noise included |
| v1.4.4 | hand-cleaned prose, one shape |
| v1.5.0 | **empty** — the extractor found no heading matching the tag |
| v2.0.0-rc.2 | 452 lines, 5,429 words |

This adopts the shape the sibling analyzer repositories already use: install one-liners, a download table, then GitHub's categorized `What's Changed` generated from a new `.github/release.yml`. The hand-written CHANGELOG section stays the announcement's seed, which is where prose belongs.

A changelog entry explains a change to a maintainer. A release body tells a user what to install and what moved. Conflating them is what produced both the 5,429-word wall and the blank release.

Two details worth review:

- The version is derived from `GITHUB_REF` rather than a `steps.tag_name` output, which this workflow does not define — the copied-in reference would have expanded to empty.
- PyPI normalizes `2.0.0-rc.2` to `2.0.0rc2`, and the built artifacts carry the normalized spelling, so the install line and asset links must too. Done with `sed` rather than `packaging.version`, because this step runs on the runner's bare `python3`, not the uv-managed environment. The normalization is verified against `packaging.version` for `rc`, `alpha`, `beta` and plain releases.

The already-published bodies for v1.4.3, v1.4.4, v1.5.0 and v2.0.0-rc.2 have been rewritten by hand into this shape, and every PR reference in them was checked to exist.