### PR TITLE
docs: fix the logo on PyPI — raw URL, and the variant that reads on white

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-<img src="https://github.com/codellm-devkit/.github/blob/main/profile/assets/cldk-dark.png" alt="Codellm-Devkit logo">
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/codellm-devkit/.github/main/profile/assets/cldk-dark.png">
+  <img src="https://raw.githubusercontent.com/codellm-devkit/.github/main/profile/assets/cldk-light.png" alt="Codellm-Devkit logo">
+</picture>
 
 <p align='center'>
   <a href="https://arxiv.org/abs/2410.13007">


### PR DESCRIPTION
The logo does not render on PyPI. Two faults, not one.

**The URL served HTML.** It pointed at `github.com/…/blob/…/cldk-dark.png`, which returns `text/html`, not an image:

```
$ curl -sI https://github.com/codellm-devkit/.github/blob/main/profile/assets/cldk-dark.png
content-type: text/html; charset=utf-8
```

GitHub rewrites blob URLs inside its own renderer, so it looked correct in the repository and broke everywhere else. That is why it survived this long.

**The asset was the wrong one.** `cldk-dark.png` has a mean luminance of 180/255 across its visible pixels — it is drawn to sit on a *dark* background. PyPI's page is white, so fixing only the URL would have traded a broken image for a nearly invisible one. `cldk-light.png` measures 94/255 and is the one that reads on white.

A `<picture>` serves both audiences. Verified against `readme_renderer`, the library PyPI itself uses to render descriptions: it keeps the inner `<img>` and strips `<source>`, so PyPI gets the light-background logo, while GitHub honours the reader's theme.

```
logo img PyPI will serve: <img src="https://raw.githubusercontent.com/…/cldk-light.png" alt="Codellm-Devkit logo">
that URL returns: 200 image/png 356119 bytes
<source> stripped by PyPI (so the fallback is used): True
```

The same fix is on the 2.0 line in #348. Note that PyPI renders each release's description from its uploaded distribution, so already-published versions keep the broken logo; this takes effect from the next release on each line.