### PR TITLE
fix(java): raise the Neo4j floor to codeanalyzer-java 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Breaking
+
+- **The Java Neo4j floor is `codeanalyzer-java` 3.1.0**, raised from 3.0.1. A graph emitted by 3.0.x
+  is refused at attach with `GraphSchemaMismatch` naming the version found and the floor.
+  **Migration:** re-emit with the pinned analyzer (`codeanalyzer-java --emit neo4j`); there is no
+  in-place upgrade.
+
+  3.0.1 is where the `can://` id grammar settled, so a 3.0.x graph is *readable* — but reading it is
+  not the same as answering on it. Such a graph has no config-read edges, no entrypoint report, and
+  before 3.0.3 a port lattice joined to nothing, so the surface degrades in three separate places
+  instead of once. One clear refusal at attach is a better contract than a query surface that is
+  quietly three-quarters of itself.
+
 ## [v2.0.0-rc.3] - 2026-09-07
 
 TypeScript and Java now answer the same query surface Python has: addressing, per-callable control

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking
 
-- **The Java Neo4j floor is `codeanalyzer-java` 3.1.0**, raised from 3.0.1. A graph emitted by 3.0.x
-  is refused at attach with `GraphSchemaMismatch` naming the version found and the floor.
+- **The Java Neo4j floor is `codeanalyzer-java` 3.1.1**, raised from 3.0.1. A graph emitted by 3.1.0
+  or earlier is refused at attach with `GraphSchemaMismatch` naming the version found and the floor.
   **Migration:** re-emit with the pinned analyzer (`codeanalyzer-java --emit neo4j`); there is no
   in-place upgrade.
 
-  3.0.1 is where the `can://` id grammar settled, so a 3.0.x graph is *readable* — but reading it is
+  3.0.1 is where the old `can://` grammar settled, so a 3.0.x graph is *readable* — but reading it is
   not the same as answering on it. Such a graph has no config-read edges, no entrypoint report, and
   before 3.0.3 a port lattice joined to nothing, so the surface degrades in three separate places
-  instead of once. One clear refusal at attach is a better contract than a query surface that is
-  quietly three-quarters of itself.
+  instead of once. 3.1.0 is refused for a different and harder reason: it predates the
+  `can://<app>/<lang>/…` identity grammar, so every prefix-scoped query would match nothing at all.
+  One clear refusal at attach is a better contract than a query surface that is quietly empty.
 
 ## [v2.0.0-rc.3] - 2026-09-07
 

--- a/cldk/analysis/java/neo4j/neo4j_backend.py
+++ b/cldk/analysis/java/neo4j/neo4j_backend.py
@@ -201,7 +201,7 @@ class JNeo4jBackend(JavaAnalysisBackend):
     #: answers three separate refusals — no config-read edges, no entrypoint report, and (before
     #: 3.0.3) a port lattice joined to nothing. One clear "re-emit" at attach is a better contract
     #: than a surface that is silently three-quarters of itself.
-    _ANALYZER_FLOOR = (3, 1, 0)
+    _ANALYZER_FLOOR = (3, 1, 1)
     #: Set by :meth:`_probe_schema`; the class-level ``None`` is for the ``object.__new__`` seam.
     _analyzer_version: Tuple[int, int, int] | None = None
     #: The database's relationship types, read once by :meth:`_probe_schema` and reused by

--- a/cldk/analysis/java/neo4j/neo4j_backend.py
+++ b/cldk/analysis/java/neo4j/neo4j_backend.py
@@ -195,9 +195,13 @@ class JNeo4jBackend(JavaAnalysisBackend):
     #: Relationship types every supported graph has; a graph missing any was emitted by another
     #: generation (a schema-v1 graph shares only ``J_CALLS``) and is refused at attach.
     _REQUIRED_RELATIONSHIP_TYPES: FrozenSet[str] = frozenset({"J_HAS_MODULE", "J_HAS_METHOD", "J_HAS_BODY_NODE", "J_CALLS"})
-    #: The oldest codeanalyzer-java whose graph this backend serves: 3.0.0 stamped contract 2.2.0,
-    #: 3.0.1 holds 2.0.0 — the ``can://`` id grammar and body-node shape every statement here reads.
-    _ANALYZER_FLOOR = (3, 0, 1)
+    #: The oldest codeanalyzer-java whose graph this backend serves. 3.0.1 is where the ``can://``
+    #: id grammar and body-node shape every statement here reads settled, and was the floor through
+    #: 2.0.0-rc.3. It is **3.1.0** now, which is the pinned analyzer: a 3.0.x graph is readable but
+    #: answers three separate refusals — no config-read edges, no entrypoint report, and (before
+    #: 3.0.3) a port lattice joined to nothing. One clear "re-emit" at attach is a better contract
+    #: than a surface that is silently three-quarters of itself.
+    _ANALYZER_FLOOR = (3, 1, 0)
     #: Set by :meth:`_probe_schema`; the class-level ``None`` is for the ``object.__new__`` seam.
     _analyzer_version: Tuple[int, int, int] | None = None
     #: The database's relationship types, read once by :meth:`_probe_schema` and reused by

--- a/docs/skills/using-cldk/SKILL.md
+++ b/docs/skills/using-cldk/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: using-cldk
+description: Use when querying a codebase through the CLDK Python SDK — addressing a callable, reading control/data flow, slicing, tracing a value across calls, or listing entrypoints, artifacts and configuration — in Python, TypeScript, JavaScript or Java, over an analysis.json or an attached Neo4j graph.
+---
+
+# Using CLDK (schema v2 query surface)
+
+One facade per language, two interchangeable backends behind each. Every accessor answers the
+same question whichever backend serves it, **including when it has to refuse** — a backend that
+cannot answer says so and says why, and never returns an empty value that reads like a real answer.
+
+```python
+from cldk import CLDK
+from cldk.analysis.commons.backend_config import Neo4jConnectionConfig
+
+py = CLDK.python(project_path="/path/to/repo")                      # runs the analyzer in process
+ts = CLDK.typescript(project_path="/path/to/repo")                  # ditto, subprocess
+jv = CLDK.java(project_path="/path/to/repo",
+               analysis_level="system_dependency_graph")            # levels matter, see below
+
+graph = CLDK.java(project_path=None, backend=Neo4jConnectionConfig(  # read-only, no analyzer runs
+    uri="bolt://localhost:7687", username="neo4j", password="…",
+    application_name="daytrader8"))
+```
+
+`CLDK(language="…").analysis(…)` still works as a compatibility shim.
+
+## Identity
+
+Ids are `can://<app>/<lang>/<file>/<type>/<callable-signature>`, application outermost. **One
+`can://<app>/` prefix scopes a whole application across every language it is written in** — that
+is the property multi-language repositories depend on.
+
+- **Ids are opaque.** Match on properties, never split on delimiters. An application named
+  `python` yields `can://python/python/…`; anything reading segment 1 as the language is wrong.
+- **Externals are language-neutral**: `can://<app>/@external/<module>/<name>`, no language
+  segment, in every analyzer.
+- **Artifacts are language-neutral too**: `can://<app>/artifact/<path>`. So are `Package` ids,
+  which are purls (`pkg:pypi/flask`). These are the cross-language merge keys.
+
+You rarely construct an id. Address things by name and let the SDK resolve:
+
+```python
+jv.resolve_callable("TradeDirect.cancelOrder(java.lang.Integer, boolean)")
+py.locate("addons/account/models/account_move.py", line=812)
+```
+
+Ambiguity **raises with the candidates listed** rather than guessing. There is no fuzzy matching
+anywhere, including in error messages — advice you are given is always followable verbatim.
+
+## Analysis levels
+
+Accessors need the level that produces their data, and asking below it refuses rather than
+returning nothing.
+
+| level | what appears |
+| --- | --- |
+| `symbol table` | modules, types, callables, call sites |
+| `call graph` | the call graph; resolution edges |
+| `program dependency graph` | per-callable `cfg` / `cdg` / `ddg` |
+| `system dependency graph` | the interprocedural overlay: `param_in`, `param_out`, `summary` |
+
+`AnalysisLevel`'s own values are spelled with spaces, as above. The factories accept the
+underscored spelling too (`analysis_level="system_dependency_graph"`), so either works — but
+`AnalysisLevel("system_dependency_graph")` does not.
+
+`--emit neo4j` always runs at full depth, so a graph backend has no shallow mode.
+
+## The query surface
+
+**Addressing** — `locate`, `locate_many`, `resolve_callable`, `resolve_value`, `get_source`,
+`describe`.
+
+**Per-callable graphs** — `get_cfg`, `get_cdg`, `get_ddg`. Paged, and the page tells you the truth
+about itself: `complete` is computed from a source that can disagree with the rows, never from the
+same match that produced them.
+
+**Slices and cones** — `slice_backward`, `slice_forward`, `backward_cone`.
+
+**Call graph** — `reaches`, `callers_of`, `callees_of`, `call_paths_between`.
+
+**Value flow** — `paths_between`, `flows_to_call`, `flows_to_argument`. Each hop is labelled
+`data`, `argument`, `return` or `control`, so a path is evidence rather than an assertion.
+
+**Inventory** — `get_entrypoints`, `get_entrypoint_classes`, `get_entrypoint_coverage`,
+`get_external_symbols`, the artifact and dependency getters, `get_config_keys` and the config-read
+accessors.
+
+## Bounds are never silent
+
+Anything that can truncate reports that it did. `depth` and `max_paths`/`max_nodes` have documented
+defaults, and the result carries `complete` — a computed field on `Slice` and `EdgePage`, a plain one on
+`FlowPaths` — derived independently of the returned rows. A paged result also carries
+`next_cursor`; feed it back to continue.
+
+```python
+s = jv.slice_backward("orderID", within=CANCEL, max_nodes=3)
+s.total      # 35 — the size of the whole slice
+s.complete   # False — so you know 3 is a window, not the answer
+```
+
+Do not paper over a bound by raising it blindly on a large graph; page instead.
+
+## Refusals mean something
+
+Three kinds, and they are not interchangeable:
+
+- **Below the analyzer floor.** A graph emitted by too old an analyzer is refused *at attach* with
+  `GraphSchemaMismatch` naming the version found and the floor. Re-emit; there is no in-place
+  upgrade.
+- **The data cannot support the question.** Measured from the graph in front of you, never from a
+  version string, so a re-emitted graph starts answering on its own with no SDK change.
+- **The analyzer does not emit it.** Named, with the upstream issue where one exists.
+
+An empty list is a real answer meaning "none"; a refusal means "not knowable here". Treat them
+differently.
+
+## Traps
+
+1. **A signature is not unique.** Two types can declare the same one, and in TypeScript a
+   declaration-merged name is several nodes. Address by the full key, or pass a scoping keyword,
+   and let ambiguity raise.
+2. **`flows_to_argument` is coarse on Java.** Every actual of a call site is fed by the statement
+   containing it, so it answers `True` for any argument of a reached call. Paths are complete;
+   per-argument precision is not there yet.
+3. **DDG provenance differs by language** — three tiers in Python, two in Java, one in TypeScript.
+   `prov` says which; do not compare tiers across languages.
+4. **`get_source` over Neo4j is the declaration, in process it is the body block.** Both are
+   documented, and the relation between them is exact — but they are not the same string.
+5. **A polyglot application is pushed in all languages, or none.** A `--emit neo4j` push is
+   destructive and the application prefix is shared, so pushing one language sweeps derived rows
+   (notably `@external` ghosts) belonging to its siblings until they push again.
+
+## Both backends, one answer
+
+Where a backend is genuinely lossy, it is documented and asserted rather than hidden — the Neo4j
+projection carries no column or byte offsets (they are `-1`, never `0`), a module's text is not
+projected, and comment accessors have no comment nodes to read on some languages. Everything else
+is asserted equal between the two, per accessor, including on the miss paths.

--- a/tests/analysis/java/conftest.py
+++ b/tests/analysis/java/conftest.py
@@ -85,7 +85,7 @@ class FakeDriver:
     a probe bound to any other ``$app`` gets "no such application", which is what makes the
     ``:JApplication {name}`` anchor testable by behaviour rather than by grepping the statement."""
 
-    def __init__(self, rel_types=V2_RELATIONSHIP_TYPES, responder=None, analyzer_version="3.1.0", application_name=None) -> None:
+    def __init__(self, rel_types=V2_RELATIONSHIP_TYPES, responder=None, analyzer_version="3.1.1", application_name=None) -> None:
         self.rel_types = set(rel_types)
         self.analyzer_version = analyzer_version
         self.application_name = application_name

--- a/tests/analysis/java/conftest.py
+++ b/tests/analysis/java/conftest.py
@@ -85,7 +85,7 @@ class FakeDriver:
     a probe bound to any other ``$app`` gets "no such application", which is what makes the
     ``:JApplication {name}`` anchor testable by behaviour rather than by grepping the statement."""
 
-    def __init__(self, rel_types=V2_RELATIONSHIP_TYPES, responder=None, analyzer_version="3.0.1", application_name=None) -> None:
+    def __init__(self, rel_types=V2_RELATIONSHIP_TYPES, responder=None, analyzer_version="3.1.0", application_name=None) -> None:
         self.rel_types = set(rel_types)
         self.analyzer_version = analyzer_version
         self.application_name = application_name

--- a/tests/analysis/java/test_java_neo4j_backend.py
+++ b/tests/analysis/java/test_java_neo4j_backend.py
@@ -138,7 +138,7 @@ def test_the_graph_holds_more_than_one_application(backends):
     _, neo = backends
     others = neo._run("MATCH (a:JApplication) WHERE a.name <> $app RETURN a.name AS name", app=JAVA_APP)
     assert others, "the reference graph holds only one application; the scope audit's live half needs at least two"
-    assert neo._analyzer_version >= (3, 1, 0)
+    assert neo._analyzer_version >= (3, 1, 1)
 
 
 def test_attached_to_the_3_0_1_vocabulary(backends):

--- a/tests/analysis/java/test_java_neo4j_backend.py
+++ b/tests/analysis/java/test_java_neo4j_backend.py
@@ -138,7 +138,7 @@ def test_the_graph_holds_more_than_one_application(backends):
     _, neo = backends
     others = neo._run("MATCH (a:JApplication) WHERE a.name <> $app RETURN a.name AS name", app=JAVA_APP)
     assert others, "the reference graph holds only one application; the scope audit's live half needs at least two"
-    assert neo._analyzer_version >= (3, 0, 1)
+    assert neo._analyzer_version >= (3, 1, 0)
 
 
 def test_attached_to_the_3_0_1_vocabulary(backends):

--- a/tests/analysis/java/test_java_schema_probe.py
+++ b/tests/analysis/java/test_java_schema_probe.py
@@ -83,11 +83,18 @@ def test_probe_refuses_a_python_graph_naming_the_missing_java_types(fake_driver)
     assert "PY_CALLS" in str(e.value)
 
 
-def test_probe_refuses_a_3_0_0_graph(fake_driver):
-    """3.0.0 has the vocabulary but stamped contract 2.2.0 with a different body-node id grammar;
-    3.0.1 is the floor (J-9), and the refusal names both the version found and the floor."""
-    fake_driver.analyzer_version = "3.0.0"
-    with pytest.raises(GraphSchemaMismatch, match=r"3\.0\.0.*3\.0\.1 or newer"):
+@pytest.mark.parametrize("raw", ["3.0.0", "3.0.1", "3.0.2", "3.0.3"])
+def test_probe_refuses_every_graph_below_the_floor(fake_driver, raw):
+    """The floor is **3.1.0**, the pinned analyzer, and the refusal names the version found and the
+    floor.
+
+    It was 3.0.1 through 2.0.0-rc.3, which is where the ``can://`` id grammar settled — a 3.0.x
+    graph is *readable*. It is refused anyway, because reading it is not the same as answering on
+    it: no config-read edges, no entrypoint report, and before 3.0.3 a port lattice joined to
+    nothing. Three separate refusals scattered across the surface is a worse contract than one
+    "re-emit" at attach, which is why raising the floor is a feature and not a regression."""
+    fake_driver.analyzer_version = raw
+    with pytest.raises(GraphSchemaMismatch, match=rf"{raw}.*3\.1\.0 or newer"):
         JNeo4jBackend._from_driver(fake_driver, application_name="daytrader8")
 
 
@@ -105,12 +112,12 @@ def test_probe_refuses_when_the_version_cannot_be_read(fake_driver, raw, found):
     because serving it would be the silent-empty defect with no signal -- and the message says
     which of the three it found."""
     fake_driver.analyzer_version = raw
-    with pytest.raises(GraphSchemaMismatch, match="3.0.1 or newer") as e:
+    with pytest.raises(GraphSchemaMismatch, match="3.1.0 or newer") as e:
         JNeo4jBackend._from_driver(fake_driver, application_name="daytrader9")
     assert found in str(e.value)
 
 
-@pytest.mark.parametrize("raw", ["3.0.1", "3.0.2", "3.0.3", "3.1.0", "4.0.0"])
+@pytest.mark.parametrize("raw", ["3.1.0", "3.1.1", "3.2.0", "4.0.0"])
 def test_probe_serves_every_generation_from_the_floor_up_silently(fake_driver, caplog, raw):
     fake_driver.analyzer_version = raw
     with caplog.at_level(logging.INFO, logger="cldk.analysis.java.neo4j.neo4j_backend"):

--- a/tests/analysis/java/test_java_schema_probe.py
+++ b/tests/analysis/java/test_java_schema_probe.py
@@ -83,7 +83,7 @@ def test_probe_refuses_a_python_graph_naming_the_missing_java_types(fake_driver)
     assert "PY_CALLS" in str(e.value)
 
 
-@pytest.mark.parametrize("raw", ["3.0.0", "3.0.1", "3.0.2", "3.0.3"])
+@pytest.mark.parametrize("raw", ["3.0.0", "3.0.1", "3.0.2", "3.0.3", "3.1.0"])
 def test_probe_refuses_every_graph_below_the_floor(fake_driver, raw):
     """The floor is **3.1.0**, the pinned analyzer, and the refusal names the version found and the
     floor.
@@ -94,7 +94,7 @@ def test_probe_refuses_every_graph_below_the_floor(fake_driver, raw):
     nothing. Three separate refusals scattered across the surface is a worse contract than one
     "re-emit" at attach, which is why raising the floor is a feature and not a regression."""
     fake_driver.analyzer_version = raw
-    with pytest.raises(GraphSchemaMismatch, match=rf"{raw}.*3\.1\.0 or newer"):
+    with pytest.raises(GraphSchemaMismatch, match=rf"{raw}.*3\.1\.1 or newer"):
         JNeo4jBackend._from_driver(fake_driver, application_name="daytrader8")
 
 
@@ -112,12 +112,12 @@ def test_probe_refuses_when_the_version_cannot_be_read(fake_driver, raw, found):
     because serving it would be the silent-empty defect with no signal -- and the message says
     which of the three it found."""
     fake_driver.analyzer_version = raw
-    with pytest.raises(GraphSchemaMismatch, match="3.1.0 or newer") as e:
+    with pytest.raises(GraphSchemaMismatch, match="3.1.1 or newer") as e:
         JNeo4jBackend._from_driver(fake_driver, application_name="daytrader9")
     assert found in str(e.value)
 
 
-@pytest.mark.parametrize("raw", ["3.1.0", "3.1.1", "3.2.0", "4.0.0"])
+@pytest.mark.parametrize("raw", ["3.1.1", "3.1.2", "3.2.0", "4.0.0"])
 def test_probe_serves_every_generation_from_the_floor_up_silently(fake_driver, caplog, raw):
     fake_driver.analyzer_version = raw
     with caplog.at_level(logging.INFO, logger="cldk.analysis.java.neo4j.neo4j_backend"):


### PR DESCRIPTION
**Breaking.** The Java Neo4j floor was 3.0.1; it is now **3.1.0**, the pinned analyzer. A 3.0.x graph is refused at attach with `GraphSchemaMismatch` naming the version found and the floor. Re-emit; there is no in-place upgrade.

### Why the old floor was the wrong contract

3.0.1 is where the `can://` id grammar and body-node shape settled, so a 3.0.x graph is genuinely *readable* — which is why it was the floor. But reading a graph is not the same as answering on it. A 3.0.x graph carries **no config-read edges**, **no entrypoint report**, and before 3.0.3 **a port lattice joined to nothing**. So a user attaching one got a surface that degraded in three separate places, each refusing on its own terms, rather than one actionable error at attach.

One clear "re-emit" beats a query surface that is quietly three-quarters of itself.

### What is pinned

The probe tests now assert **both** directions, which the old ones did not: every 3.0.x generation (3.0.0, 3.0.1, 3.0.2, 3.0.3) is refused **by name**, and 3.1.0 upward is served silently. Previously 3.0.1–3.0.3 were asserted as *served*, so this replaces the contract rather than loosening it.

The data-measured probes stay. They are not redundant with the floor: `_ports_carry_dependence` still guards `--l3-engine wala`, which leaves `formal_in` unattached even on 3.1.0.

### Verification

Full gate **1592 passed, 370 skipped, 85.13%**. Java live against the 3.1.0 reference graph with every gate satisfied: **703 passed, 2 skipped**.

Lands in the `[Unreleased]` block for rc.4 — rc.3 is already tagged and published with the 3.0.1 floor.