### PR TITLE
chore(release): 2.0.0-rc.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v2.0.0-rc.4] - 2026-09-08
 
-### Changed — BREAKING (graph identity)
+One change, and it moves the identity of every node: the application segment of a `can://` id is
+now outermost, so a single `can://<app>/` prefix scopes a whole application across every language
+it is written in. That is what a polyglot repository needs in order to be one thing rather than
+several, and it is what the previous grammar could not express.
+
+It is breaking for anyone holding an emitted graph or a cached analysis. All three analyzers moved
+in step, the SDK pins them exactly, and each graph floor refuses the release immediately below it
+by name — because those releases attach cleanly and then answer nothing.
+
+### Breaking
 
 **The `can://` id grammar puts the application outermost**, and the SDK now reads and writes only
 that form, on all three backends:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cldk"
-version = "2.0.0-rc.3"
+version = "2.0.0-rc.4"
 description = "The official Python SDK for Codellm-Devkit."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/uv.lock
+++ b/uv.lock
@@ -300,7 +300,7 @@ wheels = [
 
 [[package]]
 name = "cldk"
-version = "2.0.0rc3"
+version = "2.0.0rc4"
 source = { editable = "." }
 dependencies = [
     { name = "codeanalyzer-python" },


### PR DESCRIPTION
Cuts `[Unreleased]` to `## [v2.0.0-rc.4]` and bumps `version`.

Analyzer pins: `codeanalyzer-java` **3.1.1**, `codeanalyzer-python` **1.5.0**, `codeanalyzer-typescript` **1.5.2** — verified installed in the environment the gate ran in.

Verified before tagging:
- Full gate **1597 passed, 370 skipped, 85.16%**.
- The heading normalised to `### Breaking`, matching every other release block; no duplicate headings, no duplicate bullets.
- `test_java_degradation.py` — the single test whose host-dependent assertion deleted rc.3's tag — passes here (9 passed). It now creates the no-build-tool condition instead of assuming the host lacks Maven.

Live suites against re-emitted new-grammar graphs, run separately: Python 598 passed, TypeScript 567 passed / 1 xfailed, Java 703 passed / 2 skipped.