### PR TITLE
docs(spec): leg 4 — taint(), the query sweep's policy layer

### DIFF
--- a/docs/design/plans/2026-09-09-leg-4a-shared-path-skeleton.md
+++ b/docs/design/plans/2026-09-09-leg-4a-shared-path-skeleton.md
@@ -238,11 +238,18 @@ def test_sdg_path_query_reproduces_the_backends_paths(P, backend):
 @pytest.mark.parametrize("P, backend", BACKENDS)
 def test_the_generated_template_still_formats(P, backend):
     """The result is a `.format()` template, not a finished statement: the runners pass `rels` and
-    `depth`. If the lift ever emitted a literal brace it would raise here rather than at runtime."""
+    `depth`.
+
+    **Corrected while implementing.** An earlier draft asserted the formatted statement contains no
+    braces. It must contain single ones — Cypher map literals need them, so `{{id:$src}}` resolving
+    to `{id:$src}` is the point. The property worth asserting is that no *doubled* brace survives,
+    which would mean an unresolved escape and a statement the server would reject.
+    """
     from cldk.analysis.commons.graphs import sdg_rel_pattern
 
     out = sdg_path_query(P, **PATHS_ARGS[P]).format(rels=sdg_rel_pattern(P), depth="")
-    assert "{" not in out and "}" not in out.replace("{{", "").replace("}}", "")
+    assert "{{" not in out and "}}" not in out, "an escape survived formatting"
+    assert "{id:$src}" in out and "{id:$dst}" in out
 ```
 
 - [ ] **Step 2: Run it to make sure it fails**
@@ -289,8 +296,23 @@ def sdg_path_query(P: str, *, node_label: str, endpoint_scope: str = "", interio
 
 - [ ] **Step 4: Run the tests and make sure they pass**
 
-Run: `uv run --all-groups pytest tests/analysis/commons/test_lifted_helpers.py -v`
-Expected: 13 passed.
+Run: `uv run --all-groups pytest tests/analysis/commons/test_lifted_helpers.py -q --no-cov`
+Expected: 29 passed.
+
+Add one test the first draft of this plan did not have, because the equality assertions do not cover
+it: **which** backend scopes what.
+
+```python
+def test_the_scope_predicates_are_written_where_the_backend_writes_them():
+    py, j, ts = (sdg_path_query(P, **PATHS_ARGS[P]) for P in ("PY", "J", "TS"))
+    assert "STARTS WITH" not in py, "Python's path statement is scoped by id, deliberately"
+    assert j.count("STARTS WITH $prefix") == 3, "Java scopes both endpoints and the interior"
+    assert ts.count("STARTS WITH $p") == 1, "TypeScript scopes the interior only"
+```
+
+Byte-equality would still pass if someone changed both the generator and the arguments together.
+This fails with a reason instead, which matters because Python's omission is a measured decision and
+not a gap.
 
 The `.replace('n.', 'a.')` on `endpoint_scope` is the one fragile line: it assumes the fragment
 names the node variable as `n.`. Only Java supplies one and it does. If a future backend supplies a

--- a/docs/design/plans/2026-09-09-leg-4a-shared-path-skeleton.md
+++ b/docs/design/plans/2026-09-09-leg-4a-shared-path-skeleton.md
@@ -1,0 +1,418 @@
+# Leg 4a — the shared SDG path skeleton
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Lift the triplicated SDG path Cypher into one generator in `commons/graphs.py`, with **no
+behaviour change** — every generated statement byte-identical to the constant it replaces.
+
+**Architecture:** Three Neo4j backends each carry `_VIA_CASE`, `_PATH_ORDER` and `_PATHS`.
+`_VIA_CASE` and `_PATH_ORDER` are byte-identical across all three, so they become
+`via_case(P)` / `path_order(P)`. `_PATHS` differs in five places, all of which become parameters of
+one `sdg_path_query()`. Nothing else moves: the runner methods, the projections consumed downstream,
+and the statements' semantics are untouched.
+
+**Tech Stack:** Python 3.11+, pytest, no new dependency. Neo4j is not required — every test here
+compares strings.
+
+**Spec:** `docs/design/specs/2026-09-09-leg-4-taint.md` (T8, §2's fourth fact, §8 step 1)
+
+## Global Constraints
+
+- **No behaviour change.** This plan changes no query's semantics. The completion criterion for
+  every task is string equality against the current constant, not a live query.
+- **No public accessor changes name, signature or return type.** Nothing in this plan touches a
+  facade.
+- The three backends are **shipped code on `release/2.0` mid-rc** (`v2.0.0-rc.4`). Byte-identity is
+  what keeps the refactor from being the thing that reddens a live suite.
+- Java's relationship variable in `_PATHS` is `e`; Python's and TypeScript's is `r`. It is
+  semantically inert and **must not be normalised in this plan** — pass it as a parameter so
+  byte-identity holds. Normalising is a separate, arguable change.
+- Python's path statements are scoped **by id**, which
+  `tests/analysis/python/test_neo4j_multi_application_scope.py` sanctions as one of four scope kinds
+  for a measured reason. **Do not "fix" Python to carry `STARTS WITH`** — that is a behaviour change,
+  it was measured and rejected, and #381 was closed as not a defect for exactly this.
+- Do not delete `_paths()`'s unused `prefix=` keyword argument here. It is dead, it is cosmetic, and
+  it is not this plan's business.
+
+## File Structure
+
+| File | Responsibility after this plan |
+| --- | --- |
+| `cldk/analysis/commons/graphs.py` | gains `via_case(P)`, `path_order(P)`, `sdg_path_query(...)` alongside the existing `sdg_rels` / `sdg_rel_pattern` / `via_table` / `hop_sort_key` / `flow_path` family |
+| `cldk/analysis/python/neo4j/neo4j_backend.py` | `_VIA_CASE` / `_PATH_ORDER` deleted; `_PATHS` becomes one `sdg_path_query(...)` call |
+| `cldk/analysis/java/neo4j/neo4j_backend.py` | same |
+| `cldk/analysis/typescript/neo4j/neo4j_backend.py` | same |
+| `tests/analysis/commons/test_lifted_helpers.py` | gains the byte-identity assertions (the file already exists and is the right home) |
+
+`graphs.py` is 370 lines and already owns this family, so no new module. It grows by roughly 60 lines.
+
+---
+
+### Task 1: `via_case()` and `path_order()`
+
+The two pure duplicates. Both are currently built at class-definition time from the module-level
+`VIA` (`via_table("PY")` / `("J")` / `("TS")`), so the lifted forms take `P` and rebuild the same
+table internally.
+
+**Files:**
+- Modify: `cldk/analysis/commons/graphs.py` (append after `via_table`, around line 158)
+- Test: `tests/analysis/commons/test_lifted_helpers.py`
+
+**Interfaces:**
+- Consumes: `via_table(P)` — already in this module.
+- Produces: `via_case(P: str) -> str`, `path_order(P: str) -> str`. Task 3 replaces three class
+  attributes with calls to these.
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/analysis/commons/test_lifted_helpers.py`:
+
+```python
+import pytest
+
+from cldk.analysis.commons.graphs import path_order, via_case
+from cldk.analysis.java.neo4j.neo4j_backend import JNeo4jBackend
+from cldk.analysis.python.neo4j.neo4j_backend import PyNeo4jBackend
+from cldk.analysis.typescript.neo4j.neo4j_backend import TSNeo4jBackend
+
+#: Each backend's relationship-type prefix, and the class whose constants it must reproduce.
+BACKENDS = [("PY", PyNeo4jBackend), ("J", JNeo4jBackend), ("TS", TSNeo4jBackend)]
+
+
+@pytest.mark.parametrize("P, backend", BACKENDS)
+def test_via_case_reproduces_the_backends_constant(P, backend):
+    """The lift is only safe if it is byte-identical: a changed CASE arm would change which word a
+    hop is reported under, and a changed ORDER BY would change which paths max_paths keeps."""
+    assert via_case(P) == backend._VIA_CASE
+
+
+@pytest.mark.parametrize("P, backend", BACKENDS)
+def test_path_order_reproduces_the_backends_constant(P, backend):
+    assert path_order(P) == backend._PATH_ORDER
+
+
+def test_the_three_backends_agreed_before_the_lift():
+    """The premise of lifting these two rather than parameterising them: all three were already
+    identical. If this ever fails, one backend diverged and the lift is hiding it."""
+    assert len({b._VIA_CASE for _, b in BACKENDS}) == 1
+    assert len({b._PATH_ORDER for _, b in BACKENDS}) == 1
+```
+
+- [ ] **Step 2: Run it to make sure it fails**
+
+Run: `uv run --all-groups pytest tests/analysis/commons/test_lifted_helpers.py -v`
+Expected: FAIL with `ImportError: cannot import name 'via_case'`.
+
+- [ ] **Step 3: Implement the minimal code**
+
+In `cldk/analysis/commons/graphs.py`, after `via_table`:
+
+```python
+def via_case(P: str) -> str:
+    """The Cypher ``CASE`` that maps a hop's relationship type to the caller's word for it.
+
+    Computed in Cypher rather than in Python because the ``ORDER BY`` in :func:`path_order` sorts by
+    the same vocabulary :func:`hop_sort_key` sorts by. Ordering by the raw ``type(r)`` instead would
+    be just as deterministic and a *different* order (``PY_CDG`` before ``PY_DDG`` before
+    ``PY_PARAM_IN``, against ``argument`` before ``control`` before ``data``), so the two backends
+    would truncate ``max_paths`` to different witnesses.
+    """
+    return "CASE type(relationships(p)[i]) " + " ".join(f"WHEN '{rel}' THEN '{word}'" for rel, word in via_table(P).items()) + " ELSE type(relationships(p)[i]) END"
+
+
+def path_order(P: str) -> str:
+    """One sort key per path, ordered exactly as Python would order the tuple :func:`hop_sort_key`
+    builds.
+
+    ``\\u0001`` is the separator rather than ``|`` for one reason: string comparison agrees with
+    field-by-field comparison **only** when the separator sorts below every character a field can
+    hold, and ``|`` (0x7C) sorts *above* every lowercase letter, which would order a variable ``x``
+    after ``xy``. ``elementId`` is the last field of each hop and breaks the tie between parallel
+    relationships a caller cannot tell apart; it is stable for repeated calls against one database
+    and means nothing outside it.
+    """
+    return "reduce(k = '', i IN range(0, length(p) - 1) | k + " + via_case(P) + " + '\\u0001' + coalesce(relationships(p)[i].var, '') " "+ '\\u0001' + nodes(p)[i + 1].id + '\\u0001' + elementId(relationships(p)[i]) + '\\u0001')"
+```
+
+- [ ] **Step 4: Run the tests and make sure they pass**
+
+Run: `uv run --all-groups pytest tests/analysis/commons/test_lifted_helpers.py -v`
+Expected: 7 passed.
+
+If `test_path_order_reproduces_the_backends_constant` fails, diff the two strings character by
+character — the likely cause is the implicit string concatenation in the original spanning two
+source lines with a space between `") "` and `"+ '\\u0001'"`. Reproduce it exactly; do not
+"tidy" the spacing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cldk/analysis/commons/graphs.py tests/analysis/commons/test_lifted_helpers.py
+git commit -m "refactor(graphs): lift via_case and path_order out of the three backends"
+```
+
+---
+
+### Task 2: `sdg_path_query()`
+
+**Files:**
+- Modify: `cldk/analysis/commons/graphs.py`
+- Test: `tests/analysis/commons/test_lifted_helpers.py`
+
+**Interfaces:**
+- Consumes: `path_order(P)` from Task 1.
+- Produces:
+
+```python
+def sdg_path_query(P: str, *, node_label: str, endpoint_scope: str = "",
+                   interior_scope: str = "", projection: str, rel_var: str = "r") -> str: ...
+```
+
+`endpoint_scope` and `interior_scope` are Cypher fragments already spelled by the caller (a
+backend's `_scoped()` output, or `"n.id STARTS WITH $prefix"`), empty when that backend does not
+carry one. `projection` is the per-node map body **without** the surrounding braces. The returned
+string is still a `.format()` template carrying `{rels}` and `{depth}`, exactly as today, so the
+runner methods are unchanged.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/analysis/commons/test_lifted_helpers.py`:
+
+```python
+from cldk.analysis.commons.graphs import sdg_path_query
+
+#: The five differences between the three `_PATHS` constants, as the arguments that reproduce each.
+#: Written out rather than derived, because a derivation that produced the wrong string would also
+#: produce the wrong expectation.
+PATHS_ARGS = {
+    "PY": dict(
+        node_label="PyBodyNode",
+        projection="ref: n.id, kind: n.kind, var: n.var, line: n.start_line, "
+        "callable: head([(c:PyCallable)-[:PY_HAS_BODY_NODE]->(n) | c.signature]), "
+        "c_line: head([(c:PyCallable)-[:PY_HAS_BODY_NODE]->(n) | c.start_line])",
+    ),
+    "J": dict(
+        node_label="JBodyNode",
+        endpoint_scope="n.id STARTS WITH $prefix",
+        interior_scope="n.id STARTS WITH $prefix",
+        projection="ref: n.id, kind: n.kind, line: n.start_line",
+        rel_var="e",
+    ),
+    "TS": dict(
+        node_label="CanNode:TSBodyNode",
+        interior_scope="(n.id STARTS WITH $p)",
+        projection="ref: n.id, kind: n.kind, of: n.of, line: n.start_line, "
+        "callable: head([(c:TSCallable)-[:TS_HAS_BODY_NODE]->(n) | c.signature]), "
+        "c_line: head([(c:TSCallable)-[:TS_HAS_BODY_NODE]->(n) | c.start_line])",
+    ),
+}
+
+
+@pytest.mark.parametrize("P, backend", BACKENDS)
+def test_sdg_path_query_reproduces_the_backends_paths(P, backend):
+    """Byte-identical, including Java's `e` relationship variable and TypeScript's parenthesised
+    scope fragment. A difference here is a behaviour change, which this plan forbids."""
+    assert sdg_path_query(P, **PATHS_ARGS[P]) == backend._PATHS
+
+
+@pytest.mark.parametrize("P, backend", BACKENDS)
+def test_the_generated_template_still_formats(P, backend):
+    """The result is a `.format()` template, not a finished statement: the runners pass `rels` and
+    `depth`. If the lift ever emitted a literal brace it would raise here rather than at runtime."""
+    from cldk.analysis.commons.graphs import sdg_rel_pattern
+
+    out = sdg_path_query(P, **PATHS_ARGS[P]).format(rels=sdg_rel_pattern(P), depth="")
+    assert "{" not in out and "}" not in out.replace("{{", "").replace("}}", "")
+```
+
+- [ ] **Step 2: Run it to make sure it fails**
+
+Run: `uv run --all-groups pytest tests/analysis/commons/test_lifted_helpers.py -k sdg_path_query -v`
+Expected: FAIL with `ImportError: cannot import name 'sdg_path_query'`.
+
+- [ ] **Step 3: Implement the minimal code**
+
+In `cldk/analysis/commons/graphs.py`:
+
+```python
+def sdg_path_query(P: str, *, node_label: str, endpoint_scope: str = "", interior_scope: str = "", projection: str, rel_var: str = "r") -> str:
+    """The shortest-path statement all three Neo4j backends issue for ``paths_between``.
+
+    ``allShortestPaths`` and not a plain variable-length match. A variable-length pattern enumerates
+    *trails*, the shape that does not terminate on a real dependence graph; ``allShortestPaths`` is a
+    bidirectional BFS and answers the pathological cases in milliseconds. ``$cap`` is
+    ``max_paths + 1`` at the call site, so one extra row reports the truncation rather than a second
+    ``count(p)`` traversal for a number the caller cannot act on.
+
+    The five per-language differences are the five parameters. ``endpoint_scope`` and
+    ``interior_scope`` are Cypher fragments over the node variable ``n``, empty for a backend whose
+    statement is scoped by id instead (see the scope-kind audit in
+    ``tests/analysis/python/test_neo4j_multi_application_scope.py`` — id-keying is sanctioned, and
+    adding a predicate to those statements was measured and rejected). ``rel_var`` exists only
+    because Java spells its relationship ``e`` and the other two spell it ``r``; the name is inert
+    and is a parameter so this lift can be byte-identical rather than a judgement call.
+
+    Returns a ``.format()`` template still carrying ``{rels}`` and ``{depth}``.
+    """
+    a_scope = f" WHERE {endpoint_scope.replace('n.', 'a.')}" if endpoint_scope else ""
+    b_scope = f" WHERE {endpoint_scope.replace('n.', 'b.')}" if endpoint_scope else ""
+    interior = f" WHERE all(n IN nodes(p) WHERE {interior_scope})" if interior_scope else ""
+    return (
+        f"MATCH (a:{node_label} {{{{id:$src}}}}){a_scope} "
+        f"MATCH (b:{node_label} {{{{id:$dst}}}}){b_scope} "
+        "MATCH p = allShortestPaths((a)-[:{rels}*1..{depth}]->(b))" + interior + " "
+        "WITH p, " + path_order(P) + " AS key ORDER BY length(p), key LIMIT $cap "
+        f"RETURN [n IN nodes(p) | {{{{{projection}}}}}] AS ns, "
+        f"[{rel_var} IN relationships(p) | {{{{via: type({rel_var}), var: {rel_var}.var, prov: {rel_var}.prov}}}}] AS rs"
+    )
+```
+
+- [ ] **Step 4: Run the tests and make sure they pass**
+
+Run: `uv run --all-groups pytest tests/analysis/commons/test_lifted_helpers.py -v`
+Expected: 13 passed.
+
+The `.replace('n.', 'a.')` on `endpoint_scope` is the one fragile line: it assumes the fragment
+names the node variable as `n.`. Only Java supplies one and it does. If a future backend supplies a
+fragment shaped differently, the parameter should become a callable — but do not pre-build that
+here.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cldk/analysis/commons/graphs.py tests/analysis/commons/test_lifted_helpers.py
+git commit -m "refactor(graphs): add sdg_path_query, reproducing all three _PATHS byte-identically"
+```
+
+---
+
+### Task 3: Replace the constants in the three backends
+
+The tests from Tasks 1 and 2 compare against `backend._PATHS`, so they keep passing **only** if the
+replacement is exact — they become the regression test for this task rather than needing new ones.
+
+**Files:**
+- Modify: `cldk/analysis/python/neo4j/neo4j_backend.py` (`_VIA_CASE` ~1590, `_PATH_ORDER` ~1600, `_PATHS` ~1615)
+- Modify: `cldk/analysis/java/neo4j/neo4j_backend.py` (~898, ~918, ~933)
+- Modify: `cldk/analysis/typescript/neo4j/neo4j_backend.py` (~1847, ~1854, ~1867)
+
+**Interfaces:**
+- Consumes: `via_case`, `path_order`, `sdg_path_query` from Tasks 1-2.
+- Produces: nothing new. `_PATHS` remains a class attribute of the same name and type, because
+  `tests/analysis/python/test_neo4j_multi_application_scope.py` enumerates class attributes that are
+  `str` and starting with a Cypher clause — a `_PATHS` that stopped being a plain class-level string
+  would silently drop out of that audit, and
+  `test_the_audit_sees_the_dataflow_statements_too` names it explicitly so it would fail loudly.
+
+- [ ] **Step 1: Run the audit tests first, to record the baseline**
+
+Run: `uv run --all-groups pytest tests/analysis/python/test_neo4j_multi_application_scope.py -v`
+Expected: all pass. Note the count; it must not change.
+
+- [ ] **Step 2: Replace in the Python backend**
+
+Delete `_VIA_CASE` and `_PATH_ORDER` (keeping their comments above `_PATHS` where they explain the
+statement), and replace `_PATHS` with:
+
+```python
+    _PATHS = sdg_path_query(
+        "PY",
+        node_label="PyBodyNode",
+        projection="ref: n.id, kind: n.kind, var: n.var, line: n.start_line, "
+        "callable: head([(c:PyCallable)-[:PY_HAS_BODY_NODE]->(n) | c.signature]), "
+        "c_line: head([(c:PyCallable)-[:PY_HAS_BODY_NODE]->(n) | c.start_line])",
+    )
+```
+
+Add `sdg_path_query` (and `via_case`/`path_order` if `_CALL_PATHS` still references the deleted
+`_PATH_ORDER` — it does; point it at `path_order("PY")`) to the `cldk.analysis.commons.graphs`
+import.
+
+- [ ] **Step 3: Run the tests**
+
+Run: `uv run --all-groups pytest tests/analysis/commons/test_lifted_helpers.py tests/analysis/python -v`
+Expected: pass, with the same count as Step 1 for the audit file.
+
+- [ ] **Step 4: Repeat for Java and TypeScript**
+
+Java (note `rel_var="e"` and both scope fragments):
+
+```python
+    _PATHS = sdg_path_query(
+        "J",
+        node_label="JBodyNode",
+        endpoint_scope="n.id STARTS WITH $prefix",
+        interior_scope="n.id STARTS WITH $prefix",
+        projection="ref: n.id, kind: n.kind, line: n.start_line",
+        rel_var="e",
+    )
+```
+
+TypeScript (interior only, and the fragment comes from the module's own `_scoped`):
+
+```python
+    _PATHS = sdg_path_query(
+        "TS",
+        node_label="CanNode:TSBodyNode",
+        interior_scope=_scoped("n"),
+        projection="ref: n.id, kind: n.kind, of: n.of, line: n.start_line, "
+        "callable: head([(c:TSCallable)-[:TS_HAS_BODY_NODE]->(n) | c.signature]), "
+        "c_line: head([(c:TSCallable)-[:TS_HAS_BODY_NODE]->(n) | c.start_line])",
+    )
+```
+
+- [ ] **Step 5: Run the full offline suite**
+
+Run: `uv run --all-groups pytest tests -x -q`
+Expected: the same pass/skip counts as before this plan. **Use `--all-groups`, not
+`--all-extras`** — `--all-extras` builds a 58-package environment against `--all-groups`' 148 and
+produces phantom failures.
+
+- [ ] **Step 6: Confirm no duplicate remains**
+
+Run:
+```bash
+grep -rn "_VIA_CASE\|_PATH_ORDER = " cldk/analysis/*/neo4j/neo4j_backend.py
+```
+Expected: no output. Any hit is a copy the lift missed.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add cldk/analysis/*/neo4j/neo4j_backend.py
+git commit -m "refactor(neo4j): the three backends build _PATHS from the shared generator"
+```
+
+---
+
+### Task 4: Live confirmation
+
+String equality proves the statements did not change. It does not prove the backends still work,
+because a mis-wired import or a stale attribute would pass every test above.
+
+**Files:** none. This task runs tests only.
+
+- [ ] **Step 1: Run each language's live dataflow suite against a real graph**
+
+```bash
+uv run --all-groups pytest tests/analysis/python/test_dataflow.py -q
+uv run --all-groups pytest tests/analysis/java/test_java_dataflow_live.py -q
+uv run --all-groups pytest tests/analysis/typescript/test_typescript_dataflow_live.py -q
+```
+
+Expected: the same counts as before the plan. These need the `CLDK_TEST_NEO4J_*` variables pointing
+at graphs emitted by the pinned analyzer generations; they skip cleanly when absent, and **a skip is
+not a pass** — if all three skip, this task is not done.
+
+- [ ] **Step 2: Confirm `paths_between` returns identical witnesses**
+
+For one known reachable pair per language, capture `[h.via for h in path.hops]` before and after
+(use `git stash` to compare). Expected: identical lists in identical order. `max_paths` truncates a
+*total order*, so a changed order would silently change which witnesses a caller sees — the one
+regression byte-identity cannot rule out if the lift accidentally reordered the `ORDER BY` terms.
+
+- [ ] **Step 3: Commit nothing; report the counts**
+
+This task produces evidence, not a diff. Record the three counts in the PR body.

--- a/docs/design/plans/2026-09-09-leg-4a-shared-path-skeleton.md
+++ b/docs/design/plans/2026-09-09-leg-4a-shared-path-skeleton.md
@@ -93,11 +93,21 @@ def test_path_order_reproduces_the_backends_constant(P, backend):
     assert path_order(P) == backend._PATH_ORDER
 
 
-def test_the_three_backends_agreed_before_the_lift():
-    """The premise of lifting these two rather than parameterising them: all three were already
-    identical. If this ever fails, one backend diverged and the lift is hiding it."""
-    assert len({b._VIA_CASE for _, b in BACKENDS}) == 1
-    assert len({b._PATH_ORDER for _, b in BACKENDS}) == 1
+def test_the_three_constants_differ_only_in_the_relationship_prefix():
+    """What is and is not shared, stated exactly.
+
+    **Corrected while implementing.** An earlier draft of this plan asserted the three constants were
+    byte-identical. They are not: three distinct values each, because every CASE arm names its own
+    language's relationship types (``J_DDG`` at 244 characters against ``PY_DDG`` at 250). What was
+    triplicated is the *expression*; the result was always per-language, which is exactly why the
+    lifted forms take ``P`` and are functions rather than constants. A divergence beyond the prefix
+    fails here rather than being absorbed into a parameter silently.
+    """
+    assert len({via_case(P) for P, _ in BACKENDS}) == 3
+    assert len({path_order(P) for P, _ in BACKENDS}) == 3
+    for P in ("J", "TS"):
+        assert via_case(P).replace(f"{P}_", "PY_") == via_case("PY")
+        assert path_order(P).replace(f"{P}_", "PY_") == path_order("PY")
 ```
 
 - [ ] **Step 2: Run it to make sure it fails**
@@ -138,10 +148,18 @@ def path_order(P: str) -> str:
 
 - [ ] **Step 4: Run the tests and make sure they pass**
 
-Run: `uv run --all-groups pytest tests/analysis/commons/test_lifted_helpers.py -v`
-Expected: 7 passed.
+Run: `uv run --all-groups pytest tests/analysis/commons/test_lifted_helpers.py -q --no-cov`
+Expected: 22 passed.
 
-If `test_path_order_reproduces_the_backends_constant` fails, diff the two strings character by
+**Pass `--no-cov`.** One test file exercises ~42% of the package against a 50% `--cov-fail-under`
+floor, so the run reports `FAIL Required test coverage of 50% not reached` on top of a green suite.
+That is the floor, not a failure.
+
+Also register both names in this file's existing `LIFTED` table (the
+`cldk.analysis.commons.graphs` list), so the "lives in commons, and `python.backend` re-exports the
+same object" audit covers them alongside their siblings.
+
+If `test_path_order_reproduces_each_backends_constant` fails, diff the two strings character by
 character — the likely cause is the implicit string concatenation in the original spanning two
 source lines with a space between `") "` and `"+ '\\u0001'"`. Reproduce it exactly; do not
 "tidy" the spacing.

--- a/docs/design/plans/2026-09-09-leg-4b-taint.md
+++ b/docs/design/plans/2026-09-09-leg-4b-taint.md
@@ -31,10 +31,13 @@ Task 3 here extends `sdg_path_query`'s neighbourhood and assumes it exists.
 - **The cut happens before the bound, on both sides.** This is the spec's T7 and it is a correctness
   requirement, not a performance one. See Task 2 for why the obvious local implementation gets it
   wrong.
-- **`coalesce(r.var, '')` is mandatory** in every variable predicate. Only the DDG relationship
-  carries `var`; `PARAM_IN`, `PARAM_OUT`, `CDG` and `SUMMARY` carry none, so a bare `r.var <> $v`
-  is `null` on every cross-call hop and excludes the path. `path_order()` already spells the
-  `coalesce`, so this is the file's existing idiom.
+- **`coalesce(r.var, '')` is mandatory** in every variable predicate, and it stays mandatory even
+  though `codeanalyzer-python#195` is now fixed. As of python 1.5.1 / java 3.1.2 / typescript 1.5.3
+  both param legs carry the bound formal's `var` — but `CDG` and `SUMMARY` still carry no properties,
+  the fix writes `prune({"var": e.var})` so the key is absent whenever the formal has none, and both
+  Neo4j backends attach to graphs emitted at floors below those releases. A bare `r.var <> $v` is
+  `null` on any such hop, `all()` over it is `null`, and the path is silently excluded.
+  `path_order()` already spells the `coalesce` for the same reason, so this is the existing idiom.
 - **`depth is None` is a precondition of `exhausted`.** When `depth` is not `None`, `exhausted` is
   empty. Not "usually empty" — empty.
 - `taint()` needs **L4** (`PARAM_IN`/`PARAM_OUT` are L4 edges) and, on Java, a **connected port

--- a/docs/design/plans/2026-09-09-leg-4b-taint.md
+++ b/docs/design/plans/2026-09-09-leg-4b-taint.md
@@ -1,0 +1,688 @@
+# Leg 4b — `taint()`
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `taint()` to all three facades and all five backend implementations, as a refutation
+instrument: it returns witness paths for pairs that flow, and an `exhausted` set for pairs it
+searched to exhaustion with a clean ledger.
+
+**Architecture:** One accessor, resolved and gated once on each language's `<Lang>AnalysisBackend`
+(where the policy already lives), with the traversal supplied per backend — Cypher on the Neo4j
+side via a new `sdg_taint_query()`, in-process on the local side via `shortest_walks()`. The
+sanitizer cut must happen **inside** the search on both sides; filtering results is the one
+implementation that would be wrong.
+
+**Tech Stack:** Python 3.11+, pydantic, Neo4j 5.x, pytest. No new dependency.
+
+**Spec:** `docs/design/specs/2026-09-09-leg-4-taint.md`
+
+**Prerequisite:** `docs/design/plans/2026-09-09-leg-4a-shared-path-skeleton.md` must be complete.
+Task 3 here extends `sdg_path_query`'s neighbourhood and assumes it exists.
+
+## Global Constraints
+
+- **Five implementation sites, not three.** Python and TypeScript each have a local
+  (`codeanalyzer/codeanalyzer.py`) and a Neo4j backend that both implement `paths_between`
+  independently. **Java has one:** the policy lives on `JavaAnalysisBackend` and `JNeo4jBackend`
+  rebuilds the canonical `JApplication` and answers from it. Confirm with
+  `grep -rn "def paths_between" cldk/analysis/*/codeanalyzer/*.py cldk/analysis/*/neo4j/*.py`.
+- **The cut happens before the bound, on both sides.** This is the spec's T7 and it is a correctness
+  requirement, not a performance one. See Task 2 for why the obvious local implementation gets it
+  wrong.
+- **`coalesce(r.var, '')` is mandatory** in every variable predicate. Only the DDG relationship
+  carries `var`; `PARAM_IN`, `PARAM_OUT`, `CDG` and `SUMMARY` carry none, so a bare `r.var <> $v`
+  is `null` on every cross-call hop and excludes the path. `path_order()` already spells the
+  `coalesce`, so this is the file's existing idiom.
+- **`depth is None` is a precondition of `exhausted`.** When `depth` is not `None`, `exhausted` is
+  empty. Not "usually empty" — empty.
+- `taint()` needs **L4** (`PARAM_IN`/`PARAM_OUT` are L4 edges) and, on Java, a **connected port
+  lattice**. Reuse `_require_dataflow()` and `_require_connected_ports("taint")`; do not write new
+  gates.
+- No Neo4j 5.9 floor: `allShortestPaths` is not a quantified path pattern. Do **not** call
+  `_require_quantified_paths`.
+- **No existing public accessor changes name, signature or return type.**
+- Run pytest with `--all-groups`, never `--all-extras`.
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `cldk/analysis/commons/results.py` | `TaintResult(FlowPaths)` — the one result type, shared by all five implementations |
+| `cldk/analysis/commons/graphs.py` | `sdg_taint_query()` (the Cypher) and `shortest_walks()`'s new predicate (the in-process twin) |
+| `cldk/analysis/commons/resolve.py` | `resolve_sanitizers()` — the T6 shape/resolution agreement, once for all languages |
+| `cldk/analysis/{python,java,typescript}/backend.py` | `taint()` on each ABC: validate, resolve, gate, assemble the per-pair verdict; delegate the walk |
+| `cldk/analysis/{python,typescript}/neo4j/neo4j_backend.py` | the Cypher walk |
+| `cldk/analysis/{python,typescript}/codeanalyzer/codeanalyzer.py` | the in-process walk |
+| `cldk/analysis/{python,java,typescript}/{python,java,typescript}_analysis.py` | the facade method, docstring, example |
+| `tests/analysis/commons/test_taint_semantics.py` | new — the two soundness tripwires, language-free |
+| `tests/analysis/{python,java,typescript}/test_*_taint.py` | new — per-language offline and live |
+
+---
+
+### Task 1: `TaintResult`
+
+**Files:**
+- Modify: `cldk/analysis/commons/results.py` (append after `FlowPaths`, ~line 642)
+- Test: `tests/analysis/commons/test_taint_semantics.py` (new)
+
+**Interfaces:**
+- Consumes: `FlowPaths`, `SliceNode`, `Diagnostic` — all already in this module.
+- Produces: `TaintResult`. Every later task returns one.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+from cldk.analysis.commons.results import Diagnostic, TaintResult
+
+
+def _pair(a="a", b="b"):
+    return (a, b)
+
+
+def test_empty_and_complete_is_an_exhausted_pair():
+    """The verdict table's middle row: nothing found, and the search was whole."""
+    r = TaintResult(paths=[], complete=True, exhausted=[_pair()], roots=[], resolved="", unresolved=[])
+    assert not r                      # BoundedResult makes the payload's truth the list's
+    assert _pair() in r.exhausted
+
+
+def test_empty_and_incomplete_is_not_exhausted():
+    """The bottom row: nothing found, but something stopped the search, so no pair may be listed."""
+    d = Diagnostic(kind="unresolved_dispatch", message="x", subject="a->b")
+    r = TaintResult(paths=[], complete=False, exhausted=[], roots=[], resolved="", unresolved=[d])
+    assert not r
+    assert r.exhausted == []
+
+
+def test_a_result_behaves_as_its_path_list():
+    """Inherited from BoundedResult: `for p in result` and `len(result)` are the paths, not fields."""
+    r = TaintResult(paths=[], complete=True, exhausted=[], roots=[], resolved="", unresolved=[])
+    assert list(r) == [] and len(r) == 0
+
+
+def test_exhausted_survives_a_round_trip():
+    """A triage caller writes the result to JSON and another process reads the verdict back."""
+    r = TaintResult(paths=[], complete=True, exhausted=[_pair()], roots=[], resolved="", unresolved=[])
+    assert TaintResult.model_validate(r.model_dump()).exhausted == [_pair()]
+```
+
+Check `Diagnostic`'s actual field names first (`commons/results.py:56`) and match them; the names
+above are placeholders **only** for `Diagnostic`, and must be corrected to the real ones before the
+test is run.
+
+- [ ] **Step 2: Run it to make sure it fails**
+
+Run: `uv run --all-groups pytest tests/analysis/commons/test_taint_semantics.py -v`
+Expected: FAIL with `ImportError: cannot import name 'TaintResult'`.
+
+- [ ] **Step 3: Implement**
+
+```python
+class TaintResult(FlowPaths):
+    """Which of the requested (source, sink) pairs flow, which were searched to exhaustion, and what
+    stopped the rest.
+
+    A subclass of :class:`FlowPaths` rather than a new shape: the witnesses *are* flow paths, each
+    already carrying ``weakest``, and ``complete`` already means "were all the witnesses returned".
+    Three fields are added and nothing is redefined.
+
+    **What ``exhausted`` claims.** A pair is listed when all three hold: the call passed
+    ``depth=None``, the search found no path for it, and no :attr:`unresolved` diagnostic implicates
+    it. That is a claim about **the emitted graph plus the ledger, and never about the program** —
+    which is why the field is named for the search rather than for the conclusion. The step from
+    "exhausted" to "this alert is a false positive" is the caller's, deliberately: the DDG's
+    ``points-to`` edges over-approximate, which is the safe direction for an absence claim, but the
+    call structure *under*-approximates wherever dispatch is unresolved, so a missing call edge means
+    a real flow can exist with no path in the graph. Absence of path bounds the program only where the
+    frontier was fully resolved, and :attr:`unresolved` is what enumerates where it was not.
+
+    **Why it is stored rather than derived.** It is computable — ``all_pairs − pairs_with_paths −
+    pairs_with_unresolved`` when ``depth is None``, and ``∅`` otherwise — and that is the reason not
+    to: the load-bearing answer must not be a subtraction the caller can get wrong, and a subtraction
+    with a mode switch in front of it is worse than one without.
+
+    Attributes:
+        exhausted: The ``(source, sink)`` pairs searched to exhaustion with a clean ledger, named by
+            the same strings the caller passed. Empty whenever ``depth`` was not ``None``.
+        roots: What each selector matched, so a conclusion is auditable rather than asserted.
+        resolved: The human-readable form of ``roots``, via ``slice_resolved``.
+        unresolved: The frontier ledger. Each diagnostic names the pair it affects, so a caller can
+            tell which of forty sources was blocked rather than only that one was.
+    """
+
+    exhausted: list[Tuple[str, str]]
+    roots: list[SliceNode]
+    resolved: str
+    unresolved: list[Diagnostic]
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `uv run --all-groups pytest tests/analysis/commons/test_taint_semantics.py -v`
+Expected: 4 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cldk/analysis/commons/results.py tests/analysis/commons/test_taint_semantics.py
+git commit -m "feat(results): TaintResult, with exhausted named for the search and not the conclusion"
+```
+
+---
+
+### Task 2: `shortest_walks()` filters in **both** passes
+
+This is the task most likely to be implemented wrongly, so read the whole task before starting.
+
+`shortest_walks` (`commons/graphs.py:193`) is two passes. The first is a BFS recording `dist[node]`,
+the hop count each node was *first* reached at. The second is a DFS replay pinned to
+`target = dist[dst]`, stepping only to nodes whose recorded distance is exactly one more than the walk
+so far.
+
+**Applying a sanitizer predicate only in the DFS replay is wrong.** `dist` would still be the
+unfiltered shortest distance, so a graph whose 2-hop route is sanitized and whose 3-hop route is not
+would return **nothing**: the replay is pinned to length 2, and the 3-hop route is never visited.
+That is precisely the false refutation the spec's T7 rejects — and it would appear on the local
+backends while the Neo4j backend, whose predicate the planner inlines into the search, answers
+correctly. The two backends would disagree, and the parity suites would only notice if the corpus
+happens to contain such a shape.
+
+**The predicate must be applied in the BFS pass too**, so `dist` is the shortest *satisfying*
+distance.
+
+**Files:**
+- Modify: `cldk/analysis/commons/graphs.py` (`shortest_walks`, ~line 193)
+- Test: `tests/analysis/commons/test_taint_semantics.py`
+
+**Interfaces:**
+- Produces: `shortest_walks(..., allow_edge: Callable[[str, str | None], bool] | None = None,
+  allow_node: Callable[[str], bool] | None = None)`. `allow_edge` receives
+  `(relationship type, var)`; `allow_node` receives a node id. Both default to `None`, meaning no
+  filtering, so every existing caller is unaffected.
+
+- [ ] **Step 1: Write the failing test — the adversarial shape, in-process**
+
+```python
+from cldk.analysis.commons.graphs import shortest_walks, via_table
+
+VIA = via_table("PY")
+
+#: The shape that separates a correct filter from a plausible one: the SHORTEST route is sanitized
+#: and a LONGER one is clean. Filtering the replay alone returns nothing here.
+ADJ = {
+    "a": {"m": [("PY_DDG", "tainted", ["ssa"])], "n1": [("PY_DDG", "clean", ["ssa"])]},
+    "m": {"b": [("PY_DDG", "tainted", ["ssa"])]},
+    "n1": {"n2": [("PY_DDG", "clean", ["ssa"])]},
+    "n2": {"b": [("PY_DDG", "clean", ["ssa"])]},
+}
+
+
+def test_unfiltered_finds_the_short_route():
+    walks = shortest_walks(ADJ, "a", "b", None, 10, via=VIA)
+    assert [len(w) for w in walks] == [2]
+
+
+def test_a_sanitized_shortest_route_does_not_hide_a_clean_longer_one():
+    """The local twin of the inlining result: the search must find the shortest *satisfying* walk,
+    not filter the shortest walk. If this returns [], the predicate was applied to the replay only
+    and every local taint refutation is unsound."""
+    walks = shortest_walks(ADJ, "a", "b", None, 10, via=VIA, allow_edge=lambda rel, var: var != "tainted")
+    assert [len(w) for w in walks] == [3], "the clean 3-hop route was not found"
+
+
+def test_a_null_var_hop_is_not_cut_by_a_variable_sanitizer():
+    """PARAM_IN carries no var. A predicate that treats None as "not equal to anything" is fine; one
+    that treats it as unknown-and-therefore-excluded refutes every interprocedural flow."""
+    adj = {"a": {"p": [("PY_DDG", "clean", ["ssa"])]}, "p": {"q": [("PY_PARAM_IN", None, None)]}, "q": {"b": [("PY_DDG", "clean", ["ssa"])]}}
+    walks = shortest_walks(adj, "a", "b", None, 10, via=VIA, allow_edge=lambda rel, var: var != "tainted")
+    assert [len(w) for w in walks] == [3]
+
+
+def test_a_node_cut_removes_a_whole_callable():
+    """The callable-granular sanitizer: every body node under the callable's id prefix is cut."""
+    walks = shortest_walks(ADJ, "a", "b", None, 10, via=VIA, allow_node=lambda nid: not nid.startswith("m"))
+    assert [len(w) for w in walks] == [3]
+```
+
+- [ ] **Step 2: Run it to make sure it fails**
+
+Run: `uv run --all-groups pytest tests/analysis/commons/test_taint_semantics.py -k walks -v`
+Expected: the first test passes; the other three FAIL with `TypeError: unexpected keyword argument`.
+
+- [ ] **Step 3: Implement — one helper, used by both passes**
+
+```python
+def shortest_walks(edges, src, dst, depth, limit, *, via, allow_edge=None, allow_node=None) -> List[list]:
+    ...
+    def steps(node: str):
+        """The (destination, label) pairs the search may take from ``node``, filtered.
+
+        Used by **both** passes, and that is the whole point. The BFS records the distance each node
+        was first reached at and the DFS replay is pinned to ``dist[dst]``, so a predicate applied to
+        the replay alone would leave ``dist`` describing the unfiltered graph — a sanitized short
+        route would pin the target length and a clean longer route would never be visited, returning
+        no walk for a pair that flows. Filtering here makes ``dist`` the shortest *satisfying*
+        distance, which is what the Neo4j side gets for free from the planner inlining the predicate
+        into the shortest-path search.
+        """
+        for d, labels in edges.get(node, {}).items():
+            if allow_node is not None and not allow_node(d):
+                continue
+            kept = [lab for lab in labels if allow_edge is None or allow_edge(lab[0], lab[1])]
+            if kept:
+                yield d, kept
+```
+
+Then rewrite the BFS to iterate `steps(s)` rather than `edges.get(s, ())`, and the DFS's `options`
+comprehension to iterate `steps(node)` rather than `edges.get(node, {}).items()`. Apply `allow_node`
+to `src` as well: a source inside a cut callable yields no walk at all.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `uv run --all-groups pytest tests/analysis/commons/test_taint_semantics.py -v`
+Expected: 8 passed.
+
+- [ ] **Step 5: Prove the existing callers are unaffected**
+
+Run: `uv run --all-groups pytest tests -q -k "dataflow or paths or slice"`
+Expected: unchanged counts. Both predicates default to `None`, so this should be a no-op — if it is
+not, `steps()` changed the iteration order, which changes which walks `limit` keeps.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cldk/analysis/commons/graphs.py tests/analysis/commons/test_taint_semantics.py
+git commit -m "feat(graphs): shortest_walks filters in both passes, so a sanitized short route cannot hide a clean long one"
+```
+
+---
+
+### Task 3: `sdg_taint_query()`
+
+**Files:**
+- Modify: `cldk/analysis/commons/graphs.py`
+- Test: `tests/analysis/commons/test_lifted_helpers.py`
+
+**Interfaces:**
+- Consumes: `path_order(P)` from plan 4a.
+- Produces: `sdg_taint_query(P, *, node_label, endpoint_scope="", interior_scope="", projection,
+  rel_var="r") -> str` — same injection points as `sdg_path_query`, a different statement.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_the_taint_query_is_null_safe_and_caps_per_pair():
+    """Three properties, each of which has a specific failure mode if absent."""
+    q = sdg_taint_query("PY", node_label="PyBodyNode", projection="ref: n.id")
+    assert "coalesce(r.var, '')" in q, "a bare r.var <> $v refutes every interprocedural flow"
+    assert "collect(p)[0..$cap]" in q, "a flat LIMIT lets one prolific pair starve the rest"
+    assert "a.id IN $srcs" in q and "b.id IN $dsts" in q, "taint is m x n in one statement"
+    assert "allShortestPaths" in q, "a variable-length pattern enumerates trails and will not finish"
+
+
+def test_the_taint_query_groups_by_pair():
+    """The result must say which source reached which sink; a caller cannot recover it otherwise."""
+    q = sdg_taint_query("PY", node_label="PyBodyNode", projection="ref: n.id")
+    assert "a.id AS src" in q and "b.id AS dst" in q
+```
+
+- [ ] **Step 2: Run it; expect ImportError**
+
+- [ ] **Step 3: Implement**
+
+```python
+def sdg_taint_query(P: str, *, node_label: str, endpoint_scope: str = "", interior_scope: str = "", projection: str, rel_var: str = "r") -> str:
+    """The multi-source, multi-sink shortest-path statement behind ``taint()``.
+
+    Differs from :func:`sdg_path_query` in four ways, each load-bearing:
+
+    * **``$srcs`` / ``$dsts`` are lists**, so m sources against n sinks is one round trip and one
+      traversal per pair rather than m*n statements.
+    * **The sanitizer cut is inside the pattern**, not applied to its rows. Measured on Neo4j
+      5.26.30: an ``all()`` over ``relationships(p)`` inlines into the ``ShortestPath`` operator, so
+      the search returns the shortest *unsanitized* path. Filtering afterwards would report no flow
+      for a source whose shortest paths are all sanitized and whose next one is not — a false
+      refutation, the one answer that must never be wrong. Keep the predicate in an inlinable form:
+      a subquery or an aggregate here reintroduces the exhaustive fallback, which is trail
+      enumeration.
+    * **``coalesce(<rel>.var, '')``**, because only the DDG relationship carries ``var``. A bare
+      comparison is ``null`` on every ``PARAM_IN``/``PARAM_OUT``/``CDG``/``SUMMARY`` hop, ``all()``
+      over it is ``null``, and the path is silently excluded.
+    * **The cap is per pair** (``collect(p)[0..$cap]`` after an ordered ``WITH``), because with one
+      sink and forty sources a flat ``LIMIT`` lets one prolific pair starve the other thirty-nine,
+      and in triage the per-source witness is the answer.
+
+    ``$cut_callables`` is a list of callable ``can://`` ids; a body node's id *is*
+    ``<callable id>@<local key>``, so cutting a callable is a prefix test and needs no join.
+    ``$cut_vars`` is a list of variable names.
+    """
+    a_scope = f" AND {endpoint_scope.replace('n.', 'a.')}" if endpoint_scope else ""
+    b_scope = f" AND {endpoint_scope.replace('n.', 'b.')}" if endpoint_scope else ""
+    interior = f" AND all(n IN nodes(p) WHERE {interior_scope})" if interior_scope else ""
+    return (
+        f"MATCH (a:{node_label}) WHERE a.id IN $srcs{a_scope} "
+        f"MATCH (b:{node_label}) WHERE b.id IN $dsts{b_scope} "
+        "MATCH p = allShortestPaths((a)-[:{rels}*1..{depth}]->(b)) "
+        "WHERE all(n IN nodes(p) WHERE NOT any(q IN $cut_callables WHERE n.id STARTS WITH q))"
+        + interior + " "
+        f"AND all({rel_var} IN relationships(p) WHERE NOT coalesce({rel_var}.var, '') IN $cut_vars) "
+        "WITH a, b, p, " + path_order(P) + " AS key ORDER BY length(p), key "
+        "WITH a, b, collect(p)[0..$cap] AS ps "
+        "UNWIND ps AS p "
+        f"RETURN a.id AS src, b.id AS dst, [n IN nodes(p) | {{{{{projection}}}}}] AS ns, "
+        f"[{rel_var} IN relationships(p) | {{{{via: type({rel_var}), var: {rel_var}.var, prov: {rel_var}.prov}}}}] AS rs"
+    )
+```
+
+- [ ] **Step 4: Run the tests; expect pass**
+
+- [ ] **Step 5: Verify the plan on a real server before trusting it**
+
+Start a disposable container (**never port 7687 — it is an ssh tunnel on this machine**; 7700 was
+free at design time):
+
+```bash
+podman run -d --rm --name cldk-taint-plan -p 7700:7687 -e NEO4J_AUTH=neo4j/taintprobe123 docker.io/library/neo4j:5
+```
+
+Create the adversarial graph from the spec's §7, then `EXPLAIN` the generated statement and confirm:
+the predicates appear **inside** the `ShortestPath` operator's `Details`; there is no
+`ExhaustiveShortestPath` and no `AntiConditionalApply`; and the zero-row case plans the same way.
+Record the plan in the PR. Stop the container when done.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cldk/analysis/commons/graphs.py tests/analysis/commons/test_lifted_helpers.py
+git commit -m "feat(graphs): sdg_taint_query, with the sanitizer cut inside the pattern"
+```
+
+---
+
+### Task 4: Selector resolution and the T6 agreement
+
+**Files:**
+- Modify: `cldk/analysis/commons/resolve.py`
+- Test: `tests/analysis/commons/test_taint_semantics.py`
+
+**Interfaces:**
+- Consumes: each backend's `resolve_value(name, *, within) -> SliceNode` and
+  `resolve_callable(name, *, in_class=None, in_module=None) -> SliceNode`.
+- Produces:
+
+```python
+def resolve_sanitizers(sanitizers, *, resolve_value, resolve_callable) -> Tuple[List[str], List[str]]:
+    """Returns (cut_vars, cut_callable_ids)."""
+```
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+import pytest
+
+from cldk.analysis.commons.resolve import resolve_sanitizers
+from cldk.utils.exceptions.exceptions import SelectorNotInGraph
+
+
+def test_a_pair_cuts_a_variable_and_a_bare_name_cuts_a_callable():
+    vars_, callables = resolve_sanitizers(
+        [("token", "Handler.handle"), "html.escape"],
+        resolve_value=lambda n, within: _node(ref=f"can://app/python/h.py/handle@3:4", name=n),
+        resolve_callable=lambda n, **_: _node(ref="can://app/python/h.py/escape", name=n),
+    )
+    assert vars_ == ["token"]
+    assert callables == ["can://app/python/h.py/escape"]
+
+
+def test_a_bare_name_that_is_not_a_callable_raises_rather_than_cutting_a_variable():
+    """T6. One signature carries two semantics, so the accident of omitting `within` must be loud —
+    silently cutting the other thing is how a caller gets a confident wrong answer."""
+    with pytest.raises(SelectorNotInGraph):
+        resolve_sanitizers(["token"], resolve_value=_unused, resolve_callable=_raises)
+
+
+def test_a_pair_whose_name_is_a_callable_raises_too():
+    with pytest.raises(SelectorNotInGraph):
+        resolve_sanitizers([("html.escape", "Handler.handle")], resolve_value=_raises, resolve_callable=_unused)
+```
+
+Write `_node`, `_raises` and `_unused` as small local helpers; `_node` builds a `SliceNode` with the
+fields that model requires.
+
+- [ ] **Step 2: Run it; expect ImportError**
+
+- [ ] **Step 3: Implement**
+
+Route by shape, and let each resolver's own failure be the error — do not catch one and try the
+other, which is exactly the silent fallback T6 forbids.
+
+- [ ] **Step 4: Run the tests; expect 3 passed**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cldk/analysis/commons/resolve.py tests/analysis/commons/test_taint_semantics.py
+git commit -m "feat(resolve): sanitizer selectors route by shape, and a mismatch raises"
+```
+
+---
+
+### Task 5: `taint()` on the three ABCs
+
+The signature, the argument checks, the gates, the resolution, and the per-pair verdict assembly —
+once per language, on the class where that language's policy already lives. The traversal is an
+abstract method the concrete backends supply.
+
+**Files:**
+- Modify: `cldk/analysis/python/backend.py` (near `paths_between`, ~889)
+- Modify: `cldk/analysis/java/backend.py` (~1832)
+- Modify: `cldk/analysis/typescript/backend.py` (~811)
+- Test: `tests/analysis/{python,java,typescript}/test_*_taint.py` (new, offline)
+
+**Interfaces:**
+- Produces on each ABC:
+
+```python
+def taint(self, sources, sinks, sanitizers=(), *, depth=None, max_paths=DEFAULT_MAX_PATHS) -> TaintResult
+```
+and an abstract `_taint_walk(self, srcs, dsts, *, cut_vars, cut_callables, depth, max_paths)`
+returning `(rows_by_pair, unresolved)`.
+
+- [ ] **Step 1: Write the failing tests** — order of checks, gates, and the depth rule:
+
+```python
+def test_arguments_are_judged_before_any_resolution(backend):
+    """A malformed depth is a ValueError before a name is looked up, as on every sibling accessor."""
+    with pytest.raises(ValueError):
+        backend.taint([("x", "f")], [("y", "g")], depth=0)
+
+
+def test_empty_sources_or_sinks_is_refused_not_answered_empty(backend):
+    """cone_sinks already refuses the two ways of naming nothing; an empty answer here would be
+    indistinguishable from a refutation."""
+    with pytest.raises(ValueError):
+        backend.taint([], [("y", "g")])
+    with pytest.raises(ValueError):
+        backend.taint([("x", "f")], [])
+
+
+def test_a_bounded_depth_yields_no_exhausted_pair(backend):
+    """Condition 1 of the spec's §5, as a rule and not a tendency."""
+    r = backend.taint([("x", "f")], [("y", "g")], depth=5)
+    assert r.exhausted == []
+
+
+def test_the_same_position_pair_is_skipped_with_a_diagnostic_not_raised(backend):
+    """A deliberate divergence from paths_between, which raises: raising would discard a forty-pair
+    batch, and a caller assembling sources programmatically will hit this by accident."""
+    r = backend.taint([("x", "f")], [("x", "f")])
+    assert r.paths == [] and r.exhausted == []
+    assert any("same position" in d.message for d in r.unresolved)
+```
+
+- [ ] **Step 2: Run them; expect `AttributeError: taint`**
+
+- [ ] **Step 3: Implement on the Python ABC first**, in this order — the order is the contract:
+
+```python
+check_depth(depth); check_max_paths(max_paths)      # 1. arguments, before any round trip
+# 2. refuse empty sources/sinks
+self._require_dataflow()                             # 3. level gate
+src_nodes = [self.resolve_value(n, within=w) for n, w in sources]   # 4. resolution (may raise)
+dst_nodes = [...]
+cut_vars, cut_callables = resolve_sanitizers(...)    # 5. T6
+# 6. Java only: self._require_connected_ports("taint")
+rows, unresolved = self._taint_walk(...)             # 7. the walk
+# 8. assemble: group rows by (src, dst); exhausted = pairs with no rows and no diagnostic,
+#    ONLY when depth is None; complete = nothing truncated and not unresolved
+```
+
+- [ ] **Step 4: Run the Python offline test; expect pass. Then repeat for Java and TypeScript.**
+
+Java inserts `_require_connected_ports("taint")` after resolution — the existing accessors judge
+arguments and names *first* and mention the gap second, and `taint` must match.
+
+- [ ] **Step 5: Commit** (one commit per language keeps the review reviewable)
+
+---
+
+### Task 6: The Python walks — Neo4j and local
+
+**Files:**
+- Modify: `cldk/analysis/python/neo4j/neo4j_backend.py` (`_TAINT` constant + `_taint_walk`)
+- Modify: `cldk/analysis/python/codeanalyzer/codeanalyzer.py` (`_taint_walk` via `shortest_walks`)
+- Test: `tests/analysis/python/test_python_taint.py`, and the backend-contract test
+
+- [ ] **Step 1: Write the parity test first** — both backends, same fixture, same answer:
+
+```python
+def test_both_backends_agree_on_a_known_flow_and_on_a_refutation(local, graph):
+    for backend in (local, graph):
+        r = backend.taint(SOURCES, SINKS)
+        assert [ [h.via for h in p.hops] for p in r.paths ] == EXPECTED_HOPS
+        assert sorted(r.exhausted) == sorted(EXPECTED_EXHAUSTED)
+```
+
+Backends agreeing on a *predicate* is not agreeing on the *set* — assert the hop lists and the
+exhausted pairs, not just truthiness.
+
+- [ ] **Step 2: Run; expect failure at `_taint_walk` not implemented**
+
+- [ ] **Step 3: Implement the Neo4j walk** — `_TAINT = sdg_taint_query("PY", ...)` with the same
+      arguments plan 4a's Task 3 used for `_PATHS`, and a `_run` passing
+      `srcs`, `dsts`, `cut_vars`, `cut_callables`, `cap=max_paths + 1`.
+
+**Keep `_TAINT` a plain class-level string starting with `MATCH`**, or it drops out of
+`tests/analysis/python/test_neo4j_multi_application_scope.py`'s statement audit. Then add `"_TAINT"`
+to that file's `test_the_audit_sees_the_dataflow_statements_too` list, so it is covered explicitly
+like its siblings.
+
+- [ ] **Step 4: Implement the local walk** via `shortest_walks(..., allow_edge=..., allow_node=...)`,
+      building the predicates from `cut_vars` / `cut_callables`.
+
+- [ ] **Step 5: Per-pair starvation (spec §7 test 3).** One prolific pair and one sparse pair in the
+      same call, `max_paths=2`:
+
+```python
+def test_a_prolific_pair_does_not_starve_a_sparse_one(graph):
+    """The cap is per pair. With a flat LIMIT the prolific pair fills it and the sparse pair's only
+    witness is dropped -- reported as no flow, which in triage closes a live alert."""
+    r = graph.taint([PROLIFIC_SOURCE, SPARSE_SOURCE], [SINK], max_paths=2)
+    pairs = {(p.hops[0].frm.ref, p.hops[-1].to.ref) for p in r.paths}
+    assert len(pairs) == 2, "one pair returned no witness"
+    assert r.complete is False, "truncation must be reported, not silent (E5)"
+```
+
+Pick `PROLIFIC_SOURCE` by measurement, not guess: on odoo the heaviest callable holds 1.39M of
+5.13M DDG edges, so a source inside it has many shortest paths.
+
+- [ ] **Step 6: Run the parity test; expect pass**
+
+- [ ] **Step 7: Commit**
+
+---
+
+### Task 7: TypeScript's two walks, and Java's one
+
+**Files:**
+- Modify: `cldk/analysis/typescript/neo4j/neo4j_backend.py`, `.../codeanalyzer/codeanalyzer.py`
+- Modify: `cldk/analysis/java/backend.py` (the single shared walk) and `cldk/analysis/java/neo4j/neo4j_backend.py` if it needs the rows
+- Test: `tests/analysis/typescript/test_typescript_taint.py`, `tests/analysis/java/test_java_taint.py`
+
+- [ ] **Step 1: TypeScript, mirroring Task 6.** Its `_PATHS` scopes the interior only, so `_TAINT`
+      passes `interior_scope=_scoped("n")` and no `endpoint_scope`.
+- [ ] **Step 2: Java — one implementation.** `JNeo4jBackend` rebuilds the canonical `JApplication` and
+      answers from it, so the walk goes on `JavaAnalysisBackend` over the adjacency, via
+      `shortest_walks`. Confirm before writing: if `grep -n "def _value_paths"
+      cldk/analysis/java/neo4j/neo4j_backend.py` shows a Cypher path runner, Java has two after all
+      and needs `_TAINT` too.
+- [ ] **Step 3: Java degradation test.** On an analysis with a disconnected port lattice, `taint()`
+      raises `CodeanalyzerExecutionException` and the message names `taint`. Reuse
+      `tests/analysis/java/test_java_degradation.py`'s pattern — and note that file's lesson: it
+      *creates* the degraded condition rather than assuming the host lacks something.
+- [ ] **Step 4: Self-loop regression (spec §7 test 6).** A relationship bound twice in one `MATCH`
+      is silently dropped by Cypher's relationship-uniqueness rule — that is `#349`, which cost odoo
+      64,702 `PY_DDG` self-loops and reported `complete=True` while doing it. Java's graph has 978
+      self-loops and Python's odoo 64,702, so both can test it: a source and sink one self-loop apart
+      must return a one-hop path, not an empty result.
+
+```python
+def test_a_self_loop_is_a_path(graph):
+    r = graph.taint([SELF_LOOP_VALUE], [SELF_LOOP_VALUE_AS_SINK])
+    assert [len(p.hops) for p in r.paths] == [1]
+```
+
+      `sdg_taint_query` binds each relationship once, so this should pass as written — the test
+      exists because the shape is easy to reintroduce, and because 3b required it for the same reason.
+
+- [ ] **Step 5: Every language's backend-contract test lists `taint`**, so a backend that forgets it
+      fails rather than inheriting an abstract method.
+- [ ] **Step 6: Commit per language**
+
+---
+
+### Task 8: The facades, the corpus check, and the docs
+
+**Files:**
+- Modify: `cldk/analysis/python/python_analysis.py` (after `flows_to_argument`, ~1371)
+- Modify: `cldk/analysis/java/java_analysis.py` (~1637), `cldk/analysis/typescript/typescript_analysis.py`
+- Modify: `docs/agent-api-reference.md`, `docs/skills/using-cldk/SKILL.md`, `CLAUDE.md`, `CHANGELOG.md`
+- Test: the live suites
+
+- [ ] **Step 1: Check the corpus before writing the sanitizer tests.**
+
+*A corpus that cannot exercise a case makes a green suite meaningless* — this project has paid for
+that three times (Java `get_test_methods()` agreed across backends only because daytrader8 has zero
+`@Test` methods; TypeScript's `implements_types` subtraction was a no-op on 0 of 207 classes;
+`$anon$N` collisions were invisible until ThingsBoard). So: find in the reference graphs (a) a
+validating guard whose variable is on a flow, and (b) a transforming sanitizer call on a flow. Record
+what you found, per language. **If either is absent, building the fixture is part of this task** —
+a sanitizer test on a corpus with no sanitizer asserts nothing.
+
+- [ ] **Step 2: Add the facade method** on all three, delegating to the backend, with a docstring
+      carrying a runnable example and the `exhausted` contract. Copy `paths_between`'s docstring
+      shape; it is the house style.
+
+- [ ] **Step 3: Run the three live suites and record three numbers each** — a found flow, an
+      exhausted pair, and a forty-source batch. Exhaustion is triage's common case and must be
+      measured as its own number, not inferred from the found case.
+
+- [ ] **Step 4: Prove the tripwire is live.** Delete the `coalesce` from `sdg_taint_query`, run
+      `tests/analysis/commons/test_taint_semantics.py`, confirm it **fails**, restore it. A tripwire
+      nobody has seen fail is a test whose failure mode is unverified.
+
+- [ ] **Step 5: Docs.** `CLAUDE.md`'s per-language notes gain `taint` (and any degradation it
+      inherits); `CHANGELOG.md` gets the entry under a heading matching the release tag literally, or
+      the release workflow refuses to publish.
+
+- [ ] **Step 6: Full gate**
+
+```bash
+uv run --all-groups make test
+```
+Expected: green, coverage above the floor. This is the gate the release workflow runs, and a red
+`make test` **deletes the tag** it was cut from.
+
+- [ ] **Step 7: Commit and open the PR closing #382**

--- a/docs/design/specs/2026-09-09-leg-4-taint.md
+++ b/docs/design/specs/2026-09-09-leg-4-taint.md
@@ -54,10 +54,30 @@ at 0.054 s against 0.046 s. Java re-measured the same shape on ThingsBoard's lar
 backward cone: **9.6 / 9.9 / 9.9 ms with the predicate against 9.2 / 9.5 / 9.1 without, identical
 rows.**
 
-**Only the DDG relationship carries `var`.** `codeanalyzer-python` 1.5.0's projection writes
-`{P}_PARAM_IN` and `{P}_PARAM_OUT` with no properties at all (`project.py:260-270`), and
-`{P}_CDG`/`{P}_SUMMARY` likewise. So `r.var` is null on four of the five relationship types,
-**including both interprocedural ones**. §7 turns this into the leg's first test.
+**`var` is absent from some SDG relationship types, and which ones depends on the analyzer
+generation.** As designed against the rc.4 pins, `codeanalyzer-python` 1.5.0 wrote `{P}_PARAM_IN` and
+`{P}_PARAM_OUT` with no properties at all, so `r.var` was null on four of the five types — including
+both interprocedural ones. **That was filed as `codeanalyzer-python#195` and fixed in lockstep across
+all three analyzers** (python 1.5.1 / #196, java 3.1.2 / #250, typescript 1.5.3 / #197): both param
+legs now carry the bound formal's `var`.
+
+**The null-safe predicate remains mandatory**, for three reasons that survive the fix:
+
+1. `{P}_CDG` and `{P}_SUMMARY` still carry no properties at all — two of five types.
+2. The fix writes `prune({"var": e.var})`, so the key is absent on any param edge whose formal has no
+   variable. Present-usually is not present-always, and a predicate cannot tell the difference.
+3. Both Neo4j backends attach to graphs they did not emit, at floors below these releases. A graph
+   from 1.5.0 has no param `var` at all.
+
+What the fix *does* change is precision, in the direction `#195` argued for: a variable-granular
+sanitizer can now follow a value **across a call boundary**, because the `var` is on the param edge
+rather than only on the intraprocedural DDG hops either side of it.
+
+The degradation on an older graph is real but points the safe way. There, `coalesce(r.var, '')` yields
+`''`, which is not in `$cut_vars`, so the hop is kept and a sanitized path is **reported as a flow** —
+the caller investigates something already sanitized. Annoying, not dangerous, and the opposite of the
+null-logic trap, which cuts the path and reports a refutation. It is measurable from the data (does
+any `{P}_PARAM_IN` carry `var`?), so §6 reports it rather than leaving it silent.
 
 **The Cypher is triplicated; the Python-side helpers are not.** `hop_sort_key` and `flow_path`
 already live in `commons/graphs.py`. `_VIA_CASE` and `_PATH_ORDER` are **byte-identical** across all
@@ -308,9 +328,16 @@ mid-rc:
    families, and Java's id-derived owner recovery adopted by Python and TypeScript, each with its own
    before/after measurement.
 
-No analyzer release is required, and no version pin moves: rc.4's pins (`codeanalyzer-java` 3.1.1,
-`codeanalyzer-python` 1.5.0, `codeanalyzer-typescript` 1.5.2) already carry everything `taint()`
-reads.
+No analyzer release is required — `taint()` reads only what rc.4's pins already emit. But three
+patch releases landed after this spec was first written, all fixing `#195` in lockstep
+(**python 1.5.1**, **java 3.1.2**, **typescript 1.5.3**), and they improve `taint()`'s sanitizer
+precision across call boundaries rather than enabling anything.
+
+**Moving the pins is therefore a judgement call, and this spec does not make it.** Arguments for:
+`taint()`'s headline mechanism gets more precise, and a variable-granular cut is the one the spec's
+T5 says only a variable-granular sanitizer can sever. Argument against: it is a pin move during an rc
+for a precision gain, not a correctness fix, and the floors would move with it. Either way the
+null-safe predicate stays, so no code differs between the two choices.
 
 ## 9. Out of scope
 

--- a/docs/design/specs/2026-09-09-leg-4-taint.md
+++ b/docs/design/specs/2026-09-09-leg-4-taint.md
@@ -1,0 +1,321 @@
+# Leg 4 — `taint()`, the query sweep's policy layer
+
+Status: design locked 2026-09-09. Epic `codellm-devkit/.github#55`, leg 4 of its release plan.
+Ships `2.0.0` final.
+
+Leg 4 is the last leg. Legs 1/1.5/1.6 (Python), 2.5a/2.5b (TypeScript) and 3a/3b (Java) delivered
+the query surface on all three languages; `taint()` is the one verb in the epic's plan that no
+language has, and this spec is what it becomes.
+
+---
+
+## 1. Contract-impact triage
+
+**Does this change the schema v2 output?** No. `taint()` reads the SDG the analyzers already emit —
+the five relationship types `{P}_DDG`, `{P}_CDG`, `{P}_PARAM_IN`, `{P}_PARAM_OUT`, `{P}_SUMMARY` —
+and derives nothing the graph does not carry. No new node kind, edge kind, field, level or id shape.
+
+**Which repos are touched?**
+
+| Change type | Analyzers | SDKs | Docs |
+| --- | --- | --- | --- |
+| New facade surface (one accessor, three languages) | — | `python-sdk` | `docs/agent-api-reference.md`, `docs/skills/using-cldk/SKILL.md`, `CLAUDE.md` |
+
+One repo. Two issues found while designing this leg are filed and tracked separately, and neither
+gates it: `codeanalyzer-python#195` (schema declares a property the projection never writes) and
+`python-sdk#381` (Python's value traversals ignore the scope prefix).
+
+## 2. Where the surface stands (measured 2026-09-09, at `af133c8` = `v2.0.0-rc.4`)
+
+Every flow verb exists on all three facades. `taint` exists nowhere:
+
+```
+locate  get_ddg  get_cfg  get_cdg  reaches  paths_between
+slice_backward  slice_forward  backward_cone
+flows_to_call  flows_to_argument        →  python  java  typescript
+taint                                  →    —       —        —
+```
+
+Four facts about the existing implementations shape every decision below.
+
+**The path query is `allShortestPaths`, not a quantified path pattern.** `_PATHS` records why: a
+variable-length pattern enumerates *trails*, the shape that never terminated (killed at 600 s);
+`allShortestPaths` is a bidirectional BFS and answers the pathological cases in 0.08 s on the
+440,270-node forward cone. A consequence worth stating early: `taint()` inherits no Neo4j 5.9 floor,
+unlike `reaches` and `backward_cone`, which need quantified paths and call
+`_require_quantified_paths`.
+
+**An interior `all()` predicate is already the idiom, and it is nearly free.** `_CALL_PATHS` carries
+`all(n IN nodes(p) WHERE n:PyCallable)` with the note that Neo4j inlines an `all()` node predicate
+into the shortest-path search itself, so the route found is the shortest *satisfying* one — measured
+at 0.054 s against 0.046 s. Java re-measured the same shape on ThingsBoard's largest `formal_in`
+backward cone: **9.6 / 9.9 / 9.9 ms with the predicate against 9.2 / 9.5 / 9.1 without, identical
+rows.**
+
+**Only the DDG relationship carries `var`.** `codeanalyzer-python` 1.5.0's projection writes
+`{P}_PARAM_IN` and `{P}_PARAM_OUT` with no properties at all (`project.py:260-270`), and
+`{P}_CDG`/`{P}_SUMMARY` likewise. So `r.var` is null on four of the five relationship types,
+**including both interprocedural ones**. §7 turns this into the leg's first test.
+
+**The Cypher is triplicated; the Python-side helpers are not.** `hop_sort_key` and `flow_path`
+already live in `commons/graphs.py`. `_PATHS`, `_VIA_CASE` and `_PATH_ORDER` are each written three
+times, and they differ in more than labels: Python has no scope predicate, Java scopes endpoints and
+interior, TypeScript scopes the interior via `_scoped()`; Python projects `n.var`, TypeScript also
+`n.of`, Java neither.
+
+## 3. Decisions
+
+Each was taken against a stated alternative. Four of the nine (T2, T3, T4, T8) reject a new concept
+the §5.4 sketch or the obvious reading would have introduced — a framework catalogue, a verdict enum,
+a `Selector` type, a third copy of the path Cypher. The rest add exactly one thing each and say what
+it buys.
+
+| # | Decision | Why |
+| --- | --- | --- |
+| **T1** | **Design against alert triage — prove *or refute* a scanner's sink.** The sink arrives from outside as a position; the sources are a caller-supplied set. | It is the use case the evidence base measures (513 alerts quarantined for want of a `file:line → enclosing callable` lookup), and it is the one whose failure mode is asymmetric: a wrong refutation closes a live alert. Proving needs no new verb — `locate()` addresses the sink, `paths_between` returns the witness, `.weakest` caps the claim. **Refuting is what has no answer today**, because a caller who gets nothing back cannot distinguish "no flow exists" from "the flow left the resolved graph". `taint()` is a refutation instrument. |
+| **T2** | **The SDK ships no vocabulary.** Sources, sinks and sanitizers are the caller's to supply; no framework catalogue, no entrypoint-derived default. | Already ruled in leg 1.5 §9 ("Sources, sinks and sanitizers remain leg 4, and remain the caller's to supply"). A per-framework catalogue across three languages is a taxonomy that rots, and this leg's whole contribution is mechanism, not policy. |
+| **T3** | **A verdict is a value, not an enum.** `taint()` returns empty when it finds nothing; the existing `BoundedResult` protocol plus a `refuted` set carries the three cases. | `BoundedResult` (`commons/results.py:346`) is the one completeness protocol every bounded verb already speaks, under E5 "a bound is never silent", and it guarantees the payload behaves as its list so `if not result:` is honest. A third verdict type would be a new concept for a distinction two existing fields make. |
+| **T4** | **Address a value as `(name, within)`, made plural.** No `Selector` type, contrary to the §5.4 sketch. | It is exactly the convention `paths_between` and `flows_to_argument` already use, so the strictness (`AmbiguousName`, `SelectorNotInGraph`) is inherited unchanged and E6/E7 are satisfied by construction. |
+| **T5** | **Two sanitizer kinds, distinguished by shape.** A `(name, within)` pair cuts a **variable**; a bare `str` cuts a **callable** on the path. | They are different mechanisms wearing one word. A *validating guard* never appears on the data path — the worked example runs `@formal_in:1 → 19:8 → 22:8/actual_in:0` and never touches the guard at `20:11` — so only a variable-granular cut severs it. A *transforming* sanitizer (`html.escape`, `shlex.quote`) does sit on the path and is naturally named as a callable. Supporting only one silently fails the other. |
+| **T6** | **Shape must agree with resolution, or raise.** A bare name resolving to a variable, or a pair whose name resolves to a callable, is `SelectorNotInGraph`. | T5's one signature carries two semantics, so the accident of omitting `within` must be loud. This is the mitigation that makes T5 safe, using machinery that already exists. |
+| **T7** | **Server-side: one query, the sanitizer predicate *inside* it.** Not client-side composition over `backward_cone` + `paths_between`. | Correctness, not round trips. If sanitized paths are filtered out of a result that was already capped at `max_paths`, then a source whose twenty shortest paths are all sanitized and whose twenty-first is not comes back empty — **a false refutation**, the one output that must never be wrong. The cut has to happen before the bound, and only the server can do that. Measured in §7: the predicate inlines, so the search finds the shortest *unsanitized* path rather than filtering the shortest one. |
+| **T8** | **Lift the shared skeleton into `commons/graphs.py`** — one `sdg_path_query()` with two per-language injection points — and adopt Java's id-derived owner recovery so the projection is near-uniform. | Three copies of `_PATH_ORDER` means three copies of its U+0001-separator argument (string comparison agrees with field-by-field comparison only when the separator sorts below every character a field can hold, and `|` at 0x7C sorts above every lowercase letter), and the null-safety finding in §2 is the same species of subtlety arriving now: exactly the thing that gets fixed in one copy and not the other two. Java already recovers a vertex's owner from `ref.partition("@")[0]` "because it is cheaper than a `J_HAS_BODY_NODE` hop and because it is what makes the two backends describe a vertex identically", and states that "the graph statement need not project a callable at all". |
+| **T9** | **The cap is per-pair, not global.** `WITH a, b, collect(p)[0..$cap]`, not the flat `LIMIT $cap` `_PATHS` uses. | With one sink and forty sources a flat cap lets one prolific pair starve the other thirty-nine, and in triage the per-source witness *is* the answer. |
+
+## 4. The query
+
+```
+MATCH (a:{node_label}) WHERE a.id IN $srcs AND {scope(a)}
+MATCH (b:{node_label}) WHERE b.id IN $dsts AND {scope(b)}
+MATCH p = allShortestPaths((a)-[:{rels}*1..{depth}]->(b))
+WHERE all(n IN nodes(p) WHERE {scope(n)})
+  AND all(n IN nodes(p) WHERE NOT any(q IN $cut_callables WHERE n.id STARTS WITH q))
+  AND all(r IN relationships(p) WHERE NOT coalesce(r.var, '') IN $cut_vars)
+WITH a, b, p, {PATH_ORDER} AS key ORDER BY length(p), key
+WITH a, b, collect(p)[0..$cap] AS ps
+UNWIND ps AS p
+RETURN a.id AS src, b.id AS dst, {projection} AS ns,
+       [r IN relationships(p) | {via: type(r), var: r.var, prov: r.prov}] AS rs
+```
+
+Four things about it are load-bearing.
+
+**`coalesce(r.var, '')` is mandatory, not defensive.** Without it the predicate is three-valued
+logic: `null <> $var` is `null`, `all()` over it is `null`, and the path is excluded. Since `var` is
+null on both interprocedural relationship types (§2), the naive form **falsely refutes every
+cross-call flow**, silently, looking exactly like a clean refutation.
+
+**The callable-granular sanitizer is a prefix cut, and it is free.** A body-node id *is*
+`<callable can:// id>@<local body key>` (`codeanalyzer-python` `project.py:138-147`), so cutting a
+callable is `n.id STARTS WITH <its can:// id>` — the same shape already proven to inline. T5's second
+half needs no new mechanism.
+
+**Scoping follows Java's template, not Python's.** Every bound variable carries its own predicate,
+including the redundant one on the far endpoint, per Java's rule that "the audit judges **per bound
+variable**, and a variable whose only excuse is a predicate over an unnamed path reads to it as
+unscoped." Measured at ~4% (§2).
+
+**`$cap` is `max_paths + 1` per pair**, so one extra row reports truncation without a second
+counting traversal — `_PATHS`'s existing device, moved inside the per-pair `collect`.
+
+The shared skeleton:
+
+```python
+def sdg_path_query(P: str, *, node_label: str,
+                   scope: Callable[[str], str], projection: str) -> str: ...
+```
+
+| shared | per-language |
+| --- | --- |
+| `allShortestPaths`, the rel alternation from `sdg_rel_pattern(P)`, `PATH_ORDER`/`VIA_CASE` from `via_table(P)`, the per-pair cap | `node_label` — `PyBodyNode` / `JBodyNode` / `CanNode:TSBodyNode` |
+| the relationship projection, and the predicate vocabulary: per-bound-variable scope, prefix node cut, null-safe var cut | `scope()` — `STARTS WITH $prefix` vs TypeScript's namespace-aware `_scoped()` |
+| | `projection` — Python adds `n.var`, TypeScript also `n.of`, Java neither |
+
+## 5. What a caller sees
+
+```python
+def taint(self,
+          sources: Sequence[Tuple[str, str]],
+          sinks: Sequence[Tuple[str, str]],
+          sanitizers: Sequence[Tuple[str, str] | str] = (),
+          *, depth: int | None = None,
+          max_paths: int = DEFAULT_MAX_PATHS) -> TaintResult: ...
+```
+
+```python
+class TaintResult(FlowPaths):          # paths, complete, list behaviour, .weakest per path
+    refuted: list[Tuple[str, str]]     # (source, sink) pairs the traversal exhausted with no path
+    roots: list[SliceNode]             # what each selector matched
+    resolved: str                      # via slice_resolved()
+    unresolved: list[Diagnostic]        # the frontier ledger, tagged with the pair each affects
+```
+
+**`depth` is unbounded by default**, following `reaches` / `flows_to_*` / `paths_between` rather than
+the slices' `DEFAULT_DEPTH`. This is forced, not stylistic: at a bounded depth `taint()` could
+essentially never report `refuted`, so a bounded default would make refutation unreachable — and
+leg 1.5 already ruled that "a bounded boolean is a wrong answer, not a small one."
+
+**The verdict is per pair.** A single `complete` cannot serve m×n pairs — pair A finding flows and
+truncating would downgrade pair B's sound refutation — so `refuted` carries the verdict and
+`complete` keeps its `FlowPaths` meaning exactly:
+
+| the pair | verdict |
+| --- | --- |
+| has paths in `paths` | **flows**, and `.weakest` caps how strongly it may be stated |
+| appears in `refuted` | **refuted** — the traversal was exhaustive |
+| appears in neither | **inconclusive** — `unresolved` says why |
+
+`refuted` is *stored*, not derived. It is computable as
+`all_pairs − pairs_with_paths − pairs_with_unresolved`, and that is exactly why it should not be: the
+load-bearing answer must not be a subtraction the caller can get wrong. A refutation is earned, not
+inferred.
+
+**`weakest` is per-language by construction.** DDG provenance has three tiers in Python
+(`reaching-defs` / `points-to` / `ssa`), two in Java, one in TypeScript — so every TypeScript flow's
+`weakest` is `reaching-defs`. That is a fact to document, not a gap to close, and `prov_rank` already
+ranks an unrecognised provenance weakest of all.
+
+## 6. Errors and degradation
+
+Everything reuses existing machinery; no new exception type.
+
+| condition | behaviour |
+| --- | --- |
+| a name matches more than one thing | `AmbiguousName` |
+| a name matches nothing | `SelectorNotInGraph` |
+| a sanitizer's shape disagrees with its resolution (T6) | `SelectorNotInGraph` |
+| `depth` not a positive int, `max_paths` below 1 | `ValueError`, via `check_depth` / `check_max_paths`, **before** any round trip |
+| `sources` or `sinks` empty | refused, not answered `[]` — `cone_sinks` already "refus[es] the two ways of naming nothing" |
+| a pair where source and sink are the same position | **skipped with a diagnostic**, not raised |
+| graph below L4 | `_require_dataflow()` — `PARAM_IN`/`PARAM_OUT` are L4 edges |
+| Java analysis with a disconnected port lattice | `_require_connected_ports("taint")` — `PORTS_DISCONNECTED` |
+
+The last two are the honest-degradation cases and both already exist. `PORTS_DISCONNECTED` is a
+**data-measured** gate, never a version literal: it fires when `formal_in` vertices have out-degree
+zero over all five relationship types, which is true of `codeanalyzer-java` before 3.0.3 and under
+`--l3-engine wala`. rc.4 pins 3.1.1 and floors graphs at 3.1.1, so a conforming Java graph answers;
+a local run with the wala engine still degrades, and says so.
+
+The same-position skip is a **deliberate divergence** from `paths_between`, which raises. Raising on
+one degenerate pair would discard a forty-pair batch, and in triage a caller assembling sources
+programmatically will hit that case by accident.
+
+## 7. Verification
+
+### Probe already run (2026-09-09, Neo4j 5.26.30, disposable container)
+
+T7 rested on an assumption — that Neo4j inlines a **relationship-property** predicate into
+`allShortestPaths` the way it inlines a node-label one. Measured rather than argued, on a synthetic
+graph carrying the five real SDG relationship types:
+
+| test | result |
+| --- | --- |
+| is the relationship predicate inlined? | **yes** — appears inside `ShortestPath`'s `Details`, no trailing `Filter` |
+| does the search find the shortest *satisfying* path? | **yes** — sanitized 2-hop path cut, unsanitized 3-hop path returned |
+| compound: scope + node cut + var cut, five rel types, `*..5`? | **all three inline into one operator** |
+| refutation (zero rows) — does an exhaustive fallback appear? | **no** — no `ExhaustiveShortestPath`, no `AntiConditionalApply` |
+| naive `r.var <> $v` on a flow whose middle hop is `PARAM_IN`? | **empty** — false refutation |
+| null-safe `coalesce(r.var,'') <> $v`, same flow? | **found** |
+
+The finding this closes: the sanitized-shortest / unsanitized-longer case, which is the whole reason
+T7 beat client-side filtering, works *because* the predicate is inlined. The caveat it introduces:
+this holds for **inlinable predicate forms only**. A sanitizer expressed as a subquery or an
+aggregate reintroduces the exhaustive fallback, which is trail enumeration — the shape already
+killed at 600 s on this corpus. The spec pins the forms proven here.
+
+**Not yet measured:** wall-clock on a large graph. The plan is the same BFS that measured 0.08 s on
+the 440,270-node cone and the inlined predicates prune rather than expand, so the expectation is
+that it is cheap — but expectation is not measurement, and §10 requires the numbers.
+
+### Tests, in priority order
+
+1. **Null-safety tripwire.** An interprocedural fixture flow whose middle hop is `PARAM_IN`; fails if
+   the predicate ever loses its `coalesce`. This is the test that separates a found flow from a
+   silent false refutation.
+2. **Cut before bound.** Sanitized shortest path, unsanitized longer path, `max_paths=1`; the longer
+   path must come back. This is T7 as an assertion.
+3. **Per-pair starvation.** One prolific pair and one sparse pair in the same call; the sparse pair's
+   witness must survive.
+4. **Refuted vs inconclusive.** A pair with no route reports `refuted`; a pair whose only route
+   crosses an unresolved dispatch reports neither, and its diagnostic names the pair.
+5. **Both sanitizer kinds (T5).** A validating guard cut by variable, a transforming sanitizer cut by
+   callable, and the T6 shape/resolution disagreement raising.
+6. **Self-loop regression.** The `#349` class — a relationship bound twice in one `MATCH` silently
+   drops self-loops; the Java graph has 978.
+7. **Byte-identical lift.** The generated Cypher equals each current constant, asserted *before* the
+   projection change lands, so the refactor cannot be what reddens a live suite.
+8. **Cross-language parity and API stability.** The backend-contract test covers `taint` on all three;
+   no existing accessor changes name, signature or return type.
+
+### The corpus rule
+
+*A corpus that cannot exercise a case makes a green suite meaningless.* This project has paid for
+that lesson three times — Java `get_test_methods()` "agreed across backends" only because daytrader8
+has zero `@Test` methods; TypeScript's `implements_types` subtraction was a no-op because 0 of 207
+classes write the property; `$anon$N` collisions were invisible until ThingsBoard. **Before writing
+the tests above, confirm the reference graphs actually contain a validating guard and a transforming
+sanitizer.** If they do not, the fixture is part of the work, not a precondition of it.
+
+## 8. Release plan
+
+`taint()` is additive, so it ships in one PR per the epic's plan, on `release/2.0`, as the last leg
+before `2.0.0` final. Two steps inside it, in this order, because T8 touches three shipped backends
+mid-rc:
+
+1. **Lift with no behaviour change.** `sdg_path_query()` in `commons/graphs.py`; each backend's
+   `_PATHS` becomes a call to it; test 7 asserts byte-identical output. Nothing else moves.
+2. **`taint()` plus the projection change.** The new accessor on all three facades and both backend
+   families, and Java's id-derived owner recovery adopted by Python and TypeScript, each with its own
+   before/after measurement.
+
+No analyzer release is required, and no version pin moves: rc.4's pins (`codeanalyzer-java` 3.1.1,
+`codeanalyzer-python` 1.5.0, `codeanalyzer-typescript` 1.5.2) already carry everything `taint()`
+reads.
+
+## 9. Out of scope
+
+- **A policy vocabulary.** No framework catalogue, no entrypoint-derived source defaults (T2).
+- **Deriving edges no analyzer emitted.** The field-alias join remains an upstream question; taint
+  reads the SDG as emitted.
+- **The two issues this design found.** `codeanalyzer-python#195` and `python-sdk#381` are tracked on
+  their own and neither gates this leg. `#381` in particular is *not* a prerequisite: taint writes
+  its own scope predicates per T8/§4 regardless of what the existing Python templates do.
+- **Sanitizer inference.** Whether a callable *is* a sanitizer is the caller's judgement, always.
+- **The remaining §10 items of the facade spec** — the twelve named field-failure tests — which
+  belong to the leg but are enumerated there, not re-listed here.
+
+## 10. Definition of done
+
+- `taint()` on all three facades and both backend families, with the signature in §5 and no other
+  public accessor changing name, signature or return type.
+- `sdg_path_query()` in `commons/graphs.py`; no `_PATHS`, `_VIA_CASE` or `_PATH_ORDER` constant
+  remains duplicated across the three Neo4j backends.
+- All eight tests in §7 pass, against the live graphs and not only fixtures.
+- The null-safety tripwire (test 1) fails when `coalesce` is removed. Verified by removing it, not by
+  assuming.
+- Wall-clock for `taint()` recorded on the largest corpus in the verification set, for a found flow,
+  a refutation, and a forty-source batch. A refutation is the common case in triage and must be
+  measured as its own number, not inferred from the found case.
+- `PORTS_DISCONNECTED` and `_require_dataflow` degradation paths each exercised by a test that asserts
+  the message names the accessor.
+- `docs/agent-api-reference.md`, `docs/skills/using-cldk/SKILL.md` and `CLAUDE.md`'s per-language
+  notes updated in the same change.
+- `CHANGELOG.md` carries the addition under a heading matching the release tag literally.
+
+## 11. Caveats and known risks
+
+- **The inlining result is a property of Neo4j's planner, not of Cypher.** It was measured on 5.26.30.
+  A future server could plan a predicated `allShortestPaths` differently, and the failure mode is a
+  performance collapse into trail enumeration rather than a wrong answer. Test 2 catches the
+  correctness half; nothing pins the plan, and a plan assertion would be brittle in its own way.
+- **Wall-clock on a large graph is still unmeasured.** m×n BFS runs in one statement is the shape most
+  likely to surprise, and a forty-source batch has no measurement behind it yet.
+- **`refuted` is only as sound as `unresolved` is complete.** If a dispatch the graph could not follow
+  is *not* reported as a diagnostic, the pair lands in `refuted` and the refutation is wrong. The
+  ledger's completeness is inherited from `backward_cone` and has never been audited against a known
+  set of unresolved dispatches. That audit is the highest-value follow-up this leg does not do.
+- **T5's single signature carrying two semantics** is mitigated by T6 but not eliminated: a caller who
+  omits `within` on a name that happens to resolve as a callable gets a callable cut, silently and
+  legitimately. The names would have to collide across kinds for this to bite.
+- **The same-position skip diverges from `paths_between`'s raise.** Deliberate (§6), and it means two
+  accessors in one surface answer the same degenerate input differently. Documented on both.

--- a/docs/design/specs/2026-09-09-leg-4-taint.md
+++ b/docs/design/specs/2026-09-09-leg-4-taint.md
@@ -21,9 +21,11 @@ and derives nothing the graph does not carry. No new node kind, edge kind, field
 | --- | --- | --- | --- |
 | New facade surface (one accessor, three languages) | — | `python-sdk` | `docs/agent-api-reference.md`, `docs/skills/using-cldk/SKILL.md`, `CLAUDE.md` |
 
-One repo. Two issues found while designing this leg are filed and tracked separately, and neither
-gates it: `codeanalyzer-python#195` (schema declares a property the projection never writes) and
-`python-sdk#381` (Python's value traversals ignore the scope prefix).
+One repo. One issue found while designing this leg is filed and tracked separately, and it does not
+gate this one: `codeanalyzer-python#195` (the schema declares a `var` property on `PY_PARAM_IN` /
+`PY_PARAM_OUT` that the projection never writes). A second, `python-sdk#381`, was filed here and then
+**closed as not a defect** — §2's fourth fact records what it got wrong, because the reasoning it
+replaces is what this leg follows.
 
 ## 2. Where the surface stands (measured 2026-09-09, at `af133c8` = `v2.0.0-rc.4`)
 
@@ -58,10 +60,26 @@ rows.**
 **including both interprocedural ones**. §7 turns this into the leg's first test.
 
 **The Cypher is triplicated; the Python-side helpers are not.** `hop_sort_key` and `flow_path`
-already live in `commons/graphs.py`. `_PATHS`, `_VIA_CASE` and `_PATH_ORDER` are each written three
-times, and they differ in more than labels: Python has no scope predicate, Java scopes endpoints and
-interior, TypeScript scopes the interior via `_scoped()`; Python projects `n.var`, TypeScript also
-`n.of`, Java neither.
+already live in `commons/graphs.py`. `_VIA_CASE` and `_PATH_ORDER` are **byte-identical** across all
+three backends — pure duplicates. Only `_PATHS` genuinely differs, and in two ways: the node label,
+and the node projection (Python adds `n.var`, TypeScript also `n.of`, Java neither).
+
+The scope predicate looks like a third difference and is not. Python's `_SLICE` / `_PATHS` /
+`_VALUE_REACHES` carry no `STARTS WITH` because they are keyed **by id**, which
+`tests/analysis/python/test_neo4j_multi_application_scope.py` sanctions as one of four scope kinds:
+a body-node id embeds the application and the emitter only ever links nodes from its own run, so such
+a statement is scoped by construction — and the predicate was measured there as costing a test of
+195,784 reached nodes against a list. Java writes it anyway, on the stricter rule that "the audit
+judges the predicate that is **written**, not the graph that happens to be attached", for ~4%. Two
+documented standards, each measured on its own corpus, and reasoning by analogy between them is what
+leg 1.6's `:PyCanNode` result warned against.
+
+**This leg follows Java's**, for a reason neither backend had: `taint()`'s traversal is new code whose
+cost is not yet known, and its sanitizer predicate filters the path interior anyway, so the scope
+predicate rides along in an `all()` that is already there.
+
+`_PATH_ORDER` already spells `coalesce(relationships(p)[i].var, '')`, so the null-safe idiom §4
+requires is established practice in these files rather than something `taint()` introduces.
 
 ## 3. Decisions
 
@@ -299,9 +317,10 @@ reads.
 - **A policy vocabulary.** No framework catalogue, no entrypoint-derived source defaults (T2).
 - **Deriving edges no analyzer emitted.** The field-alias join remains an upstream question; taint
   reads the SDG as emitted.
-- **The two issues this design found.** `codeanalyzer-python#195` and `python-sdk#381` are tracked on
-  their own and neither gates this leg. `#381` in particular is *not* a prerequisite: taint writes
-  its own scope predicates per T8/§4 regardless of what the existing Python templates do.
+- **The issue this design found.** `codeanalyzer-python#195` is tracked on its own and does not gate
+  this leg. `python-sdk#381` was filed here too and **closed as not a defect** — the audit that already
+  covers those statements sanctions id-keying as a scope kind (§2). Taint writes its own
+  per-bound-variable scope predicates per T8/§4 either way.
 - **Sanitizer inference.** Whether a callable *is* a sanitizer is the caller's judgement, always.
 - **The remaining §10 items of the facade spec** — the twelve named field-failure tests — which
   belong to the leg but are enumerated there, not re-listed here.

--- a/docs/design/specs/2026-09-09-leg-4-taint.md
+++ b/docs/design/specs/2026-09-09-leg-4-taint.md
@@ -72,9 +72,9 @@ it buys.
 
 | # | Decision | Why |
 | --- | --- | --- |
-| **T1** | **Design against alert triage — prove *or refute* a scanner's sink.** The sink arrives from outside as a position; the sources are a caller-supplied set. | It is the use case the evidence base measures (513 alerts quarantined for want of a `file:line → enclosing callable` lookup), and it is the one whose failure mode is asymmetric: a wrong refutation closes a live alert. Proving needs no new verb — `locate()` addresses the sink, `paths_between` returns the witness, `.weakest` caps the claim. **Refuting is what has no answer today**, because a caller who gets nothing back cannot distinguish "no flow exists" from "the flow left the resolved graph". `taint()` is a refutation instrument. |
+| **T1** | **Design against alert triage — prove *or refute* a scanner's sink.** The sink arrives from outside as a position; the sources are a caller-supplied set. | It is the use case the evidence base measures (513 alerts quarantined for want of a `file:line → enclosing callable` lookup), and it is the one whose failure mode is asymmetric: a wrong refutation closes a live alert. Proving needs no new verb — `locate()` addresses the sink, `paths_between` returns the witness, `.weakest` caps the claim. **Refuting is what has no answer today**, because a caller who gets nothing back cannot distinguish "no flow exists" from "the flow left the resolved graph". `taint()` produces the evidence a refutation is built from, and §5 is explicit about the one step it cannot take on the caller's behalf. |
 | **T2** | **The SDK ships no vocabulary.** Sources, sinks and sanitizers are the caller's to supply; no framework catalogue, no entrypoint-derived default. | Already ruled in leg 1.5 §9 ("Sources, sinks and sanitizers remain leg 4, and remain the caller's to supply"). A per-framework catalogue across three languages is a taxonomy that rots, and this leg's whole contribution is mechanism, not policy. |
-| **T3** | **A verdict is a value, not an enum.** `taint()` returns empty when it finds nothing; the existing `BoundedResult` protocol plus a `refuted` set carries the three cases. | `BoundedResult` (`commons/results.py:346`) is the one completeness protocol every bounded verb already speaks, under E5 "a bound is never silent", and it guarantees the payload behaves as its list so `if not result:` is honest. A third verdict type would be a new concept for a distinction two existing fields make. |
+| **T3** | **A verdict is a value, not an enum.** `taint()` returns empty when it finds nothing; the existing `BoundedResult` protocol plus an `exhausted` set carries the three cases. | `BoundedResult` (`commons/results.py:346`) is the one completeness protocol every bounded verb already speaks, under E5 "a bound is never silent", and it guarantees the payload behaves as its list so `if not result:` is honest. A third verdict type would be a new concept for a distinction two existing fields make. |
 | **T4** | **Address a value as `(name, within)`, made plural.** No `Selector` type, contrary to the §5.4 sketch. | It is exactly the convention `paths_between` and `flows_to_argument` already use, so the strictness (`AmbiguousName`, `SelectorNotInGraph`) is inherited unchanged and E6/E7 are satisfied by construction. |
 | **T5** | **Two sanitizer kinds, distinguished by shape.** A `(name, within)` pair cuts a **variable**; a bare `str` cuts a **callable** on the path. | They are different mechanisms wearing one word. A *validating guard* never appears on the data path — the worked example runs `@formal_in:1 → 19:8 → 22:8/actual_in:0` and never touches the guard at `20:11` — so only a variable-granular cut severs it. A *transforming* sanitizer (`html.escape`, `shlex.quote`) does sit on the path and is naturally named as a callable. Supporting only one silently fails the other. |
 | **T6** | **Shape must agree with resolution, or raise.** A bare name resolving to a variable, or a pair whose name resolves to a callable, is `SelectorNotInGraph`. | T5's one signature carries two semantics, so the accident of omitting `within` must be loud. This is the mitigation that makes T5 safe, using machinery that already exists. |
@@ -143,32 +143,52 @@ def taint(self,
 ```
 
 ```python
-class TaintResult(FlowPaths):          # paths, complete, list behaviour, .weakest per path
-    refuted: list[Tuple[str, str]]     # (source, sink) pairs the traversal exhausted with no path
-    roots: list[SliceNode]             # what each selector matched
-    resolved: str                      # via slice_resolved()
+class TaintResult(FlowPaths):           # paths, complete, list behaviour, .weakest per path
+    exhausted: list[Tuple[str, str]]    # pairs searched to exhaustion with a clean ledger
+    roots: list[SliceNode]              # what each selector matched
+    resolved: str                       # via slice_resolved()
     unresolved: list[Diagnostic]        # the frontier ledger, tagged with the pair each affects
 ```
 
-**`depth` is unbounded by default**, following `reaches` / `flows_to_*` / `paths_between` rather than
-the slices' `DEFAULT_DEPTH`. This is forced, not stylistic: at a bounded depth `taint()` could
-essentially never report `refuted`, so a bounded default would make refutation unreachable — and
-leg 1.5 already ruled that "a bounded boolean is a wrong answer, not a small one."
+### `exhausted` — what it claims, and what it does not
+
+A pair is in `exhausted` when **all three** hold:
+
+1. **`depth is None`** for the call — the traversal was unbounded.
+2. **Zero paths** were found for that pair.
+3. **No `unresolved` diagnostic implicates** that pair.
+
+So `exhausted` is a claim about **the emitted graph plus the ledger, never about the program.** The
+field is named for what the SDK can mechanically certify, and the step from there to "this alert is
+a false positive" is the caller's to take, deliberately.
+
+That step is not free, and the reason is asymmetry in how the graph approximates. The DDG's
+`points-to` edges are *may*-edges — over-approximate, the safe direction for an absence claim. But
+the **call structure is under-approximate wherever dispatch is unresolved**, and a missing call edge
+means a real flow can exist with no path in the graph. Absence of path therefore bounds the program
+only if every call on the relevant frontier was resolved, which is exactly what `unresolved`
+enumerates. `exhausted`'s usefulness reduces entirely to that ledger's completeness — see §11.
+
+Condition 1 is a rule, not a tendency: **when `depth` is not `None`, `exhausted` is empty.** A pair
+with no path within five hops is not refuted, it is unmeasured, and conflating the two is the
+bounded-boolean error leg 1.5 named ("a bounded boolean is a wrong answer, not a small one"). This is
+also why `depth` is unbounded by default here, following `reaches` / `flows_to_*` / `paths_between`
+rather than the slices' `DEFAULT_DEPTH`.
 
 **The verdict is per pair.** A single `complete` cannot serve m×n pairs — pair A finding flows and
-truncating would downgrade pair B's sound refutation — so `refuted` carries the verdict and
+truncating would downgrade pair B's clean exhaustion — so `exhausted` carries the verdict and
 `complete` keeps its `FlowPaths` meaning exactly:
 
-| the pair | verdict |
-| --- | --- |
-| has paths in `paths` | **flows**, and `.weakest` caps how strongly it may be stated |
-| appears in `refuted` | **refuted** — the traversal was exhaustive |
-| appears in neither | **inconclusive** — `unresolved` says why |
+| the pair | what the SDK certifies | what a triage caller does with it |
+| --- | --- | --- |
+| has paths in `paths` | a witness exists; `.weakest` caps how strongly it may be stated | act on it |
+| appears in `exhausted` | searched to exhaustion, ledger clean for this pair | treat as a false positive, at the confidence §11 allows |
+| appears in neither | nothing — `unresolved` says what stopped it | do not close; the diagnostic names what to check |
 
-`refuted` is *stored*, not derived. It is computable as
-`all_pairs − pairs_with_paths − pairs_with_unresolved`, and that is exactly why it should not be: the
-load-bearing answer must not be a subtraction the caller can get wrong. A refutation is earned, not
-inferred.
+`exhausted` is *stored*, not derived. It is computable — as
+`all_pairs − pairs_with_paths − pairs_with_unresolved` when `depth is None`, and as `∅` otherwise —
+and that is exactly why it should not be: the load-bearing answer must not be a subtraction the
+caller can get wrong, and a subtraction with a mode switch in front of it is worse than one without.
 
 **`weakest` is per-language by construction.** DDG provenance has three tiers in Python
 (`reaching-defs` / `points-to` / `ssa`), two in Java, one in TypeScript — so every TypeScript flow's
@@ -236,8 +256,10 @@ that it is cheap — but expectation is not measurement, and §10 requires the n
    path must come back. This is T7 as an assertion.
 3. **Per-pair starvation.** One prolific pair and one sparse pair in the same call; the sparse pair's
    witness must survive.
-4. **Refuted vs inconclusive.** A pair with no route reports `refuted`; a pair whose only route
-   crosses an unresolved dispatch reports neither, and its diagnostic names the pair.
+4. **Exhausted vs inconclusive.** A pair with no route reports `exhausted`; a pair whose only route
+   crosses an unresolved dispatch reports neither, and its diagnostic names the pair. A third case:
+   the same call with an explicit `depth` returns `exhausted == []` even for the pair that has no
+   route at all — condition 1 of §5, asserted rather than assumed.
 5. **Both sanitizer kinds (T5).** A validating guard cut by variable, a transforming sanitizer cut by
    callable, and the T6 shape/resolution disagreement raising.
 6. **Self-loop regression.** The `#349` class — a relationship bound twice in one `MATCH` silently
@@ -294,7 +316,7 @@ reads.
 - The null-safety tripwire (test 1) fails when `coalesce` is removed. Verified by removing it, not by
   assuming.
 - Wall-clock for `taint()` recorded on the largest corpus in the verification set, for a found flow,
-  a refutation, and a forty-source batch. A refutation is the common case in triage and must be
+  an exhausted pair, and a forty-source batch. Exhaustion is the common case in triage and must be
   measured as its own number, not inferred from the found case.
 - `PORTS_DISCONNECTED` and `_require_dataflow` degradation paths each exercised by a test that asserts
   the message names the accessor.
@@ -310,8 +332,13 @@ reads.
   correctness half; nothing pins the plan, and a plan assertion would be brittle in its own way.
 - **Wall-clock on a large graph is still unmeasured.** m×n BFS runs in one statement is the shape most
   likely to surprise, and a forty-source batch has no measurement behind it yet.
-- **`refuted` is only as sound as `unresolved` is complete.** If a dispatch the graph could not follow
-  is *not* reported as a diagnostic, the pair lands in `refuted` and the refutation is wrong. The
+- **`exhausted` is only as useful as `unresolved` is complete.** The field itself stays true by
+  construction — it claims exhaustion over the emitted graph and nothing more — but the caller's step
+  from it to "false positive" inherits every gap in the ledger. If a dispatch the graph could not
+  follow is *not* reported, the pair lands in `exhausted` looking exactly like a clean one, and the
+  caller closes a live alert. Known ways the ledger can be silent because the analyzer never saw the
+  route to report it: framework-mediated routing, reflection, FFI boundaries, files that were not
+  analysed, and cross-request DB persistence, which no static SDG subsumes. The
   ledger's completeness is inherited from `backward_cone` and has never been audited against a known
   set of unresolved dispatches. That audit is the highest-value follow-up this leg does not do.
 - **T5's single signature carrying two semantics** is mitigated by T6 but not eliminated: a caller who


### PR DESCRIPTION
Locks the design for leg 4 of epic codellm-devkit/.github#55 — `taint()`, the last leg before
`2.0.0` final. Spec only; no code moves here.

**Design record for #382, which the implementation PR will close.** This PR is provenance: the
ladder's design gate wants the spec committed and the work tracked before an implementation rung
starts, and those are two artifacts, not one.

## The framing that drove the rest

Proving a flow already works. `locate()` addresses a sink arriving as `file:line`, `paths_between`
returns the witness, `.weakest` caps how strongly it may be stated. **Refuting** one has no answer
today: a caller who gets nothing back cannot distinguish "no flow exists" from "the flow left the
resolved graph at a dispatch nobody followed". For triage that is the expensive direction, because a
wrong refutation closes a live alert.

So `taint()` is designed as the instrument a refutation is built from. That decides the rest — why
`depth` is unbounded by default, why the sanitizer predicate must live inside the query rather than
filter its results, and why the result field is named `exhausted` rather than `refuted`.

## Nine decisions, four of which remove a concept

| | |
| --- | --- |
| **T2** | No framework catalogue — sources, sinks and sanitizers stay the caller's |
| **T3** | No verdict enum — `BoundedResult`'s `complete` plus a stored `exhausted` set carries all three cases |
| **T4** | No `Selector` type — the existing `(name, within)` pair, made plural |
| **T8** | No fourth copy of the path Cypher — the shared skeleton lifts into `commons/graphs.py` |

The five that add something: triage as the target use case (T1), two sanitizer kinds distinguished by
shape (T5) with shape-must-match-resolution as the mitigation (T6), the server-side cut (T7), and a
per-pair rather than global cap (T9).

## Two probe findings, with the plans that produced them

Run against Neo4j 5.26.30 on a disposable container, because T7 rested on an assumption.

**A relationship-property predicate inlines into `allShortestPaths`.** It appears inside the
`ShortestPath` operator's `Details` with no trailing `Filter` and no `ExhaustiveShortestPath`
fallback — including on the zero-row case, which is the one taint spends most of its time in. So the
search returns the shortest *unsanitized* path rather than filtering the shortest one and reporting
nothing. This is what makes the server-side cut **correct**, not merely faster: filtering a result
that was already capped at `max_paths` would report no flow for a source whose twenty shortest paths
are sanitized and whose twenty-first is not.

**Only the DDG relationship carries `var`.** `codeanalyzer-python` 1.5.0 writes `PARAM_IN` and
`PARAM_OUT` with no properties at all (`project.py:260-270`), so `r.var` is null on four of the five
SDG relationship types — including both interprocedural ones. A naive `r.var <> $v` predicate is
therefore `null` on every cross-call hop, `all()` over it is `null`, and the path is excluded:
**every interprocedural flow is falsely refuted, silently, looking exactly like a clean refutation.**
Demonstrated on the same graph — control returns the 3-hop flow, naive returns empty,
`coalesce(r.var, '')` returns it again. `coalesce` is mandatory, and the tripwire for it is the leg's
first test.

## `exhausted`, not `refuted`

The second commit renames the field. `refuted` read as a claim about the program; what the SDK can
certify is narrower, and the gap was invisible at the call site. A pair is in `exhausted` iff **all
three** hold: `depth is None`, zero paths found, and no `unresolved` diagnostic implicates it. It is
a claim about the emitted graph plus the ledger, never about the program.

Condition 1 was previously only implied — the first draft said a bounded depth meant taint "could
essentially never" report the verdict. It is now a rule: **when `depth` is not `None`, `exhausted` is
empty.** A pair with no path within five hops is not refuted, it is unmeasured.

§5 states why the step from `exhausted` to "false positive" is the caller's: the graph approximates
asymmetrically. The DDG's `points-to` edges are may-edges — over-approximate, the safe direction for
an absence claim — but the call structure is *under*-approximate wherever dispatch is unresolved, so a
missing call edge means a real flow can exist with no path. Absence of path bounds the program only
where the frontier was fully resolved.

## Filed while designing this, neither gating the leg

- codellm-devkit/codeanalyzer-python#195 — `schema.py:273-274` declares `{"var": "string"}` on
  `PY_PARAM_IN`/`PY_PARAM_OUT` while the projection writes no properties. The declaration promises a
  property that never arrives.
- #381 — Python's `_PATHS`/`_SLICE`/`_VALUE_REACHES` carry no scope predicate while Java's and
  TypeScript's do, and `_paths()` passes `prefix=` into templates that ignore it. Filed as
  consistency, explicitly **not** as a proven bug, and corrected in a follow-up comment once I found
  that Java's leg-3b had already documented the invariant and measured the predicate's cost at ~4%.

## Where to push back

The spec names its own weak point in §11: `exhausted` is only as useful as `unresolved` is complete,
and that ledger has never been audited against a known set of unresolved dispatches. Pulling that
audit into the leg rather than leaving it as follow-up is a defensible call and would make the leg
materially larger.
